### PR TITLE
Load config values from environment

### DIFF
--- a/tomic/config.py
+++ b/tomic/config.py
@@ -210,6 +210,11 @@ def load_config() -> AppConfig:
             data = _load_env(path)
 
     cfg = {**_asdict(AppConfig()), **data}
+
+    # Environment variables override file values
+    env_keys = {k: v for k, v in os.environ.items() if k in cfg}
+    cfg.update(env_keys)
+
     if "POLYGON_API_KEYS" in cfg and isinstance(cfg["POLYGON_API_KEYS"], str):
         cfg["POLYGON_API_KEYS"] = [
             k.strip() for k in cfg["POLYGON_API_KEYS"].split(",") if k.strip()


### PR DESCRIPTION
## Summary
- allow env vars to override config file values

## Testing
- `pytest -q`
- `pytest tests/providers/test_polygon_iv.py::test_fetch_polygon_iv30d_fallback -q`


------
https://chatgpt.com/codex/tasks/task_b_6877854bdf18832e8db9f223a60e8a9c