### PR TITLE
Fix AlphaVantage API key lookup

### DIFF
--- a/.github/workflows/fetch_earnings.yml
+++ b/.github/workflows/fetch_earnings.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Run earnings fetch via Alpha Vantage
         run: python -m tomic.cli.fetch_earnings_alpha
+        env:
+          ALPHAVANTAGE_API_KEY: ${{ secrets.ALPHAVANTAGE_API_KEY }}
 
       - name: Configure Git
         run: |

--- a/tomic/cli/fetch_earnings_alpha.py
+++ b/tomic/cli/fetch_earnings_alpha.py
@@ -9,6 +9,8 @@ from tempfile import TemporaryDirectory
 from time import sleep
 from typing import List
 
+import os
+
 import requests
 
 from tomic.config import get as cfg_get
@@ -78,7 +80,9 @@ def main(argv: List[str] | None = None) -> None:
     """Fetch and update earnings dates for configured symbols."""
     setup_logging()
     logger.info("\U0001F680 Earnings dates fetch")
-    api_key = cfg_get("ALPHAVANTAGE_API_KEY", "")
+    api_key = cfg_get("ALPHAVANTAGE_API_KEY", "") or os.environ.get(
+        "ALPHAVANTAGE_API_KEY", ""
+    )
     if not api_key:
         logger.error("Missing ALPHAVANTAGE_API_KEY in configuration")
         return


### PR DESCRIPTION
## Summary
- look up ALPHAVANTAGE_API_KEY from environment variables as fallback
- pass secret to GitHub Actions workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687786485bc4832ebbfcb9d340548a57