### PR TITLE
docs: show polygon API key for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,3 +309,6 @@ Functie: compute_iv_term_structure()
 ✅ Tests
 Run alle basistests met:
 pytest tests/
+
+🔍 Debugging
+Om de volledige Polygon API-sleutel te loggen, zet je de omgevingsvariabele `TOMIC_SHOW_POLYGON_KEY=1` voordat je scripts start. De sleutel wordt dan niet gemaskeerd.


### PR DESCRIPTION
## Summary
- document how to see the unmasked Polygon API key by using `TOMIC_SHOW_POLYGON_KEY`

## Testing
- `pytest tests/cli/test_cli_app.py -q`


------
https://chatgpt.com/codex/tasks/task_b_6877935d00f8832e92f99dbbbf20f3d5