### PR TITLE
refetch when atm_iv null

### DIFF
--- a/tests/cli/test_fetch_iv_polygon.py
+++ b/tests/cli/test_fetch_iv_polygon.py
@@ -62,7 +62,9 @@ def test_fetch_iv_polygon_skip_existing(monkeypatch, tmp_path):
         lambda sym: {"atm_iv": 0.22, "skew": 0.0, "term_m1_m2": None, "term_m1_m3": None},
     )
 
-    (tmp_path / "ABC.json").write_text(json.dumps([{"date": "2024-01-01"}]))
+    (tmp_path / "ABC.json").write_text(
+        json.dumps([{"date": "2024-01-01", "atm_iv": 0.1}])
+    )
 
     called = []
     monkeypatch.setattr(mod, "update_json_file", lambda *a, **k: called.append(1))
@@ -81,3 +83,44 @@ def test_fetch_iv_polygon_skip_existing(monkeypatch, tmp_path):
 
     assert not called
     assert any("al aanwezig" in m for m in messages)
+
+
+def test_fetch_iv_polygon_refetch_when_null(monkeypatch, tmp_path):
+    mod = importlib.import_module("tomic.cli.fetch_iv_polygon")
+
+    monkeypatch.setattr(mod, "setup_logging", lambda: None)
+    monkeypatch.setattr(
+        mod,
+        "cfg_get",
+        lambda name, default=None: (
+            ["ABC"]
+            if name == "DEFAULT_SYMBOLS"
+            else str(tmp_path)
+            if name == "IV_DAILY_SUMMARY_DIR"
+            else default
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "fetch_polygon_iv30d",
+        lambda sym: {"atm_iv": 0.23, "skew": 0.0, "term_m1_m2": None, "term_m1_m3": None},
+    )
+
+    (tmp_path / "ABC.json").write_text(
+        json.dumps([{"date": "2024-01-01", "atm_iv": None}])
+    )
+
+    captured = []
+    monkeypatch.setattr(mod, "update_json_file", lambda f, rec, keys: captured.append(rec))
+
+    class FakeDT(datetime):
+        @classmethod
+        def now(cls):
+            return datetime(2024, 1, 1)
+
+    monkeypatch.setattr(mod, "datetime", FakeDT)
+    monkeypatch.setattr(mod, "sleep", lambda s: None)
+
+    mod.main([])
+
+    assert captured and captured[0]["atm_iv"] == 0.23

--- a/tomic/cli/fetch_iv_polygon.py
+++ b/tomic/cli/fetch_iv_polygon.py
@@ -49,7 +49,9 @@ def main(argv: List[str] | None = None) -> None:
         file = summary_dir / f"{sym}.json"
         existing = load_json(file)
         if any(
-            isinstance(r, dict) and r.get("date") == date_str
+            isinstance(r, dict)
+            and r.get("date") == date_str
+            and r.get("atm_iv") is not None
             for r in existing
         ):
             logger.info(f"⏭️ {sym} al aanwezig voor {date_str}")


### PR DESCRIPTION
## Summary
- Skip refetch only when a symbol's daily summary already holds a non-null `atm_iv`
- Re-fetch and overwrite daily records with `atm_iv: null`
- Cover refetch logic with new unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_688e1b501850832e98419a2dbe667c8e