### PR TITLE
Fix GH Action commit steps

### DIFF
--- a/.github/workflows/fetch_earnings.yml
+++ b/.github/workflows/fetch_earnings.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           git status --short
           if [ -n "$(git status --porcelain)" ]; then
-            git add tomic/data/earnings_dates.json
+            git add tomic/data/earnings_data.json
             git commit -m "Update earnings dates"
             git push
           else

--- a/.github/workflows/fetch_prices.yml
+++ b/.github/workflows/fetch_prices.yml
@@ -53,15 +53,11 @@ jobs:
 
           if [ -n "$(git status --porcelain)" ]; then
             echo "📝 Committing changes."
-            git add tomic/data/spot_prices/*.json tomic/data/iv_daily_summary/*.json tomic/data/historical_volatility/*.json
+            git add tomic/data/spot_prices tomic/data/iv_daily_summary tomic/data/historical_volatility
             git commit -m "Update price history"
 
-            echo "🔧 Fetching and rebasing on latest origin/main."
-            git fetch origin main
-            git rebase origin/main
-
-            echo "🚀 Pushing with --force-with-lease."
-            git push origin main --force-with-lease
+            echo "🚀 Pushing changes."
+            git push origin main
           else
             echo "✅ No changes to commit"
           fi


### PR DESCRIPTION
## Summary
- Simplify fetch_prices workflow: drop rebase/force push, commit and push directly
- Fix wrong path in fetch_earnings workflow to ensure new data file is tracked

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6891c265b494832e8e5578ebb0870bef