### PR TITLE
docs: clarify earnings data metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Belangrijke mappen in `config.yaml`:
 - `EARNINGS_DATES_FILE`
 
 Het bestand `earnings_dates.json` bevat verwachte earnings per symbool. De optie "Toon marktinformatie" gebruikt dit om de eerstvolgende datum te tonen.
+Het bestand `tomic/data/earnings_data.json` bevat enkel metadata (bijv. laatste fetch-tijdstempel per symbool) en is niet nodig voor runtime-functies.
 
 Dagelijkse prijsdata wordt met `tomic/cli/fetch_prices.py` tot maximaal 504 dagen
 terug opgehaald en in `PRICE_HISTORY_DIR` opgeslagen.


### PR DESCRIPTION
## Summary
- clarify that `tomic/data/earnings_data.json` only stores fetch timestamps and isn't required at runtime

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6891ef79d83c832eac4578656146adfc