### PR TITLE
Log strike details in low-liquidity warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Krijg je geen voorstellen, dan toont TOMIC nu ook hoeveel combinaties zijn
 afgewezen door een ratioscheck of risicocriteria. Zo weet je direct waarom er
 geen strategie werd gevonden.
 
+Bij onvoldoende volume of open interest toont de log nu per strike ook volume,
+open interest en expiratie in de vorm `strike [volume, open interest, expiry]`.
+
 ⏳ Verbindingstips
 Wacht na het verbinden tot de callback `nextValidId()` is aangeroepen voordat
 je verzoeken naar TWS stuurt. Pas dan is de client klaar om orders of

--- a/tests/analysis/test_liquidity_filter.py
+++ b/tests/analysis/test_liquidity_filter.py
@@ -1,4 +1,4 @@
-from tomic.strategy_candidates import _metrics
+import tomic.strategy_candidates as sc
 
 
 def test_metrics_rejects_low_liquidity(monkeypatch):
@@ -40,7 +40,17 @@ def test_metrics_rejects_low_liquidity(monkeypatch):
             return 10
         return default
 
-    monkeypatch.setattr("tomic.strategy_candidates.cfg_get", fake_cfg_get)
-    metrics, reasons = _metrics("bull put spread", legs)
+    logged: list[str] = []
+
+    class DummyLogger:
+        def info(self, msg: str) -> None:
+            logged.append(msg)
+
+    monkeypatch.setattr(sc, "logger", DummyLogger())
+    monkeypatch.setattr(sc, "cfg_get", fake_cfg_get)
+    metrics, reasons = sc._metrics("bull put spread", legs)
     assert metrics is None
     assert any("volume" in r for r in reasons)
+    assert logged == [
+        "[bull put spread] Onvoldoende volume/open interest voor strikes 100 [0.0, 0.0, 20250101], 90 [0.0, 0.0, 20250101]"
+    ]

--- a/tomic/strategy_candidates.py
+++ b/tomic/strategy_candidates.py
@@ -326,11 +326,15 @@ def _metrics(
                 oi = float(leg.get("open_interest") or 0)
             except Exception:
                 oi = 0.0
+            exp = leg.get("expiry") or leg.get("expiration")
+            strike = leg.get("strike")
+            if isinstance(strike, float) and strike.is_integer():
+                strike = int(strike)
             if (min_vol > 0 and vol < min_vol) or (min_oi > 0 and oi < min_oi):
-                low_liq.append(str(leg.get("strike")))
+                low_liq.append(f"{strike} [{vol}, {oi}, {exp}]")
         if low_liq:
             logger.info(
-                f"[{strategy}] Onvoldoende volume/open interest voor strikes {','.join(low_liq)}"
+                f"[{strategy}] Onvoldoende volume/open interest voor strikes {', '.join(low_liq)}"
             )
             reasons.append("onvoldoende volume/open interest")
             return None, reasons


### PR DESCRIPTION
## Summary
- Include strike, volume, open interest, and expiry in low-liquidity validation
- Document low-liquidity logging format
- Test low-liquidity logs capture detailed strike data

## Testing
- `MIN_OPTION_VOLUME=0 MIN_OPTION_OPEN_INTEREST=0 pytest`


------
https://chatgpt.com/codex/tasks/task_b_6893a0394a38832e9ca841c81fc34a84