### PR TITLE
Normalize camel-case leg keys before numeric parsing

### DIFF
--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -77,6 +77,12 @@ def test_normalize_leg(monkeypatch):
     assert out2["delta"] is None
 
 
+def test_normalize_leg_camel_case():
+    leg = {"OpenInterest": "415"}
+    out = utils.normalize_leg(leg)
+    assert out == {"open_interest": 415.0}
+
+
 def test_prompt_user_for_price_accept(monkeypatch):
     inputs = iter(["y", "0.25"])
     monkeypatch.setattr("builtins.input", lambda *a: next(inputs))

--- a/tomic/utils.py
+++ b/tomic/utils.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime, date
 from pathlib import Path
 import math
+import re
 
 from tomic.config import get as cfg_get
 from tomic.journal.utils import load_json
@@ -205,14 +206,20 @@ _NUMERIC_KEYS = {
 
 
 def normalize_leg(leg: dict) -> dict:
-    """Cast numeric fields in ``leg`` to ``float`` if possible."""
+    """Cast numeric fields in ``leg`` to ``float`` if possible.
+
+    CamelCase keys are converted to ``snake_case`` before numeric parsing.
+    """
 
     for key in list(leg.keys()):
-        canonical = key.lower()
+        canonical = re.sub(r"(?<!^)(?=[A-Z])", "_", key).lower()
         val = leg[key]
         if canonical in _NUMERIC_KEYS:
             leg[canonical] = parse_euro_float(val)
             if canonical != key:
                 del leg[key]
+        elif canonical != key:
+            leg[canonical] = val
+            del leg[key]
     return leg
 


### PR DESCRIPTION
## Summary
- ensure option legs convert CamelCase keys to snake_case before casting numeric fields
- add test verifying OpenInterest becomes open_interest as float

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6893ae46458c832e97fb5a33ef874d93