### PR TITLE
Fix open interest normalization for exported chains

### DIFF
--- a/tests/api/test_market_export_open_interest.py
+++ b/tests/api/test_market_export_open_interest.py
@@ -1,0 +1,51 @@
+import csv
+
+import tomic.strategy_candidates as sc
+from tomic.api.market_export import load_exported_chain
+
+
+def test_load_exported_chain_normalizes_open_interest(tmp_path, monkeypatch):
+    csv_path = tmp_path / "chain.csv"
+    with csv_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            "Expiry",
+            "Type",
+            "Strike",
+            "OpenInterest",
+            "Bid",
+            "Ask",
+            "Delta",
+            "Model",
+            "Mid",
+            "Edge",
+        ])
+        writer.writerow([
+            "20250101",
+            "C",
+            "100",
+            "42",
+            "1",
+            "2",
+            "0.5",
+            "1",
+            "1.5",
+            "0",
+        ])
+    rows = load_exported_chain(str(csv_path))
+    assert rows[0]["open_interest"] == 42.0
+    leg = rows[0]
+    leg.update({"position": -1})
+
+    def fake_cfg_get(key, default=None):
+        if key == "MIN_OPTION_OPEN_INTEREST":
+            return 10
+        if key == "MIN_OPTION_VOLUME":
+            return 0
+        return default
+
+    monkeypatch.setattr(sc, "cfg_get", fake_cfg_get)
+    monkeypatch.setattr(sc, "calculate_margin", lambda *a, **k: 1)
+    metrics, reasons = sc._metrics("test", [leg])
+    assert metrics is not None
+    assert "onvoldoende volume/open interest" not in reasons

--- a/tomic/api/market_export.py
+++ b/tomic/api/market_export.py
@@ -119,12 +119,13 @@ def load_exported_chain(filepath: str) -> list[dict[str, Any]]:
         reader = csv.DictReader(f)
         rows = []
         for row in reader:
-            rec = {k.lower(): v for k, v in row.items()}
+            rec = dict(row)
+            normalize_leg(rec)
+            rec = {k.lower(): v for k, v in rec.items()}
             if "expiry" not in rec and "expiration" in rec:
                 rec["expiry"] = rec["expiration"]
             if "expiration" not in rec and "expiry" in rec:
                 rec["expiration"] = rec["expiry"]
-            normalize_leg(rec)
             rows.append(rec)
         return rows
 


### PR DESCRIPTION
## Summary
- Pass original CSV headers to `normalize_leg` before lowercasing so fields like `OpenInterest` become `open_interest`
- Add regression test ensuring open-interest values are preserved and consumed by strategy metrics

## Testing
- `pytest tests/api/test_market_export_open_interest.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6893b2168a54832ea03be4cc6fb6a28d