### PR TITLE
Compute edge from model mid difference in strategies

### DIFF
--- a/tomic/strategies/atm_iron_butterfly.py
+++ b/tomic/strategies/atm_iron_butterfly.py
@@ -72,6 +72,12 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
                 leg["model"] = black_scholes(opt_type, spot, strike, dte, iv, r=0.045, q=0.0)
         except Exception:
             pass
+        if (
+            leg.get("edge") is None
+            and leg.get("mid") is not None
+            and leg.get("model") is not None
+        ):
+            leg["edge"] = leg["model"] - leg["mid"]
         return normalize_leg(leg)
 
     def passes_risk(metrics: Dict[str, Any]) -> bool:

--- a/tomic/strategies/backspread_put.py
+++ b/tomic/strategies/backspread_put.py
@@ -73,6 +73,12 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
                 leg["model"] = black_scholes(opt_type, spot, strike, dte, iv, r=0.045, q=0.0)
         except Exception:
             pass
+        if (
+            leg.get("edge") is None
+            and leg.get("mid") is not None
+            and leg.get("model") is not None
+        ):
+            leg["edge"] = leg["model"] - leg["mid"]
         return normalize_leg(leg)
 
     def passes_risk(metrics: Dict[str, Any]) -> bool:

--- a/tomic/strategies/calendar.py
+++ b/tomic/strategies/calendar.py
@@ -87,6 +87,13 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
                     "position": 1,
                 },
             ]
+            for leg in legs:
+                if (
+                    leg.get("edge") is None
+                    and leg.get("mid") is not None
+                    and leg.get("model") is not None
+                ):
+                    leg["edge"] = leg["model"] - leg["mid"]
             legs = [normalize_leg(l) for l in legs]
             metrics, _ = _metrics("calendar", legs)
             if not metrics:

--- a/tomic/strategies/iron_condor.py
+++ b/tomic/strategies/iron_condor.py
@@ -75,6 +75,12 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
                 leg["model"] = black_scholes(opt_type, spot, strike, dte, iv, r=0.045, q=0.0)
         except Exception:
             pass
+        if (
+            leg.get("edge") is None
+            and leg.get("mid") is not None
+            and leg.get("model") is not None
+        ):
+            leg["edge"] = leg["model"] - leg["mid"]
         return normalize_leg(leg)
 
     def passes_risk(metrics: Dict[str, Any]) -> bool:

--- a/tomic/strategies/naked_put.py
+++ b/tomic/strategies/naked_put.py
@@ -69,6 +69,12 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
                 leg["model"] = black_scholes(opt_type, spot, strike, dte, iv, r=0.045, q=0.0)
         except Exception:
             pass
+        if (
+            leg.get("edge") is None
+            and leg.get("mid") is not None
+            and leg.get("model") is not None
+        ):
+            leg["edge"] = leg["model"] - leg["mid"]
         return normalize_leg(leg)
 
     def passes_risk(metrics: Dict[str, Any]) -> bool:

--- a/tomic/strategies/ratio_spread.py
+++ b/tomic/strategies/ratio_spread.py
@@ -74,6 +74,12 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
                 leg["model"] = black_scholes(opt_type, spot, strike, dte, iv, r=0.045, q=0.0)
         except Exception:
             pass
+        if (
+            leg.get("edge") is None
+            and leg.get("mid") is not None
+            and leg.get("model") is not None
+        ):
+            leg["edge"] = leg["model"] - leg["mid"]
         return normalize_leg(leg)
 
     def passes_risk(metrics: Dict[str, Any]) -> bool:

--- a/tomic/strategies/short_call_spread.py
+++ b/tomic/strategies/short_call_spread.py
@@ -72,6 +72,12 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
                 leg["model"] = black_scholes(opt_type, spot, strike, dte, iv, r=0.045, q=0.0)
         except Exception:
             pass
+        if (
+            leg.get("edge") is None
+            and leg.get("mid") is not None
+            and leg.get("model") is not None
+        ):
+            leg["edge"] = leg["model"] - leg["mid"]
         return normalize_leg(leg)
 
     def passes_risk(metrics: Dict[str, Any]) -> bool:

--- a/tomic/strategies/short_put_spread.py
+++ b/tomic/strategies/short_put_spread.py
@@ -72,6 +72,12 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
                 leg["model"] = black_scholes(opt_type, spot, strike, dte, iv, r=0.045, q=0.0)
         except Exception:
             pass
+        if (
+            leg.get("edge") is None
+            and leg.get("mid") is not None
+            and leg.get("model") is not None
+        ):
+            leg["edge"] = leg["model"] - leg["mid"]
         return normalize_leg(leg)
 
     def passes_risk(metrics: Dict[str, Any]) -> bool:


### PR DESCRIPTION
## Summary
- derive leg edge from model and mid price when edge is missing across strategies

## Testing
- `pytest` *(fails: 9 failed, 92 passed, 4 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_6894565dac9c832ea0e8c26d1a9efc4a