### PR TITLE
Handle legacy open interest column

### DIFF
--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -83,6 +83,12 @@ def test_normalize_leg_camel_case():
     assert out == {"open_interest": 415.0}
 
 
+def test_normalize_leg_openinterest():
+    input_leg = {"openinterest": "1289"}
+    result = utils.normalize_leg(input_leg)
+    assert result["open_interest"] == 1289
+
+
 def test_prompt_user_for_price_accept(monkeypatch):
     inputs = iter(["y", "0.25"])
     monkeypatch.setattr("builtins.input", lambda *a: next(inputs))

--- a/tomic/cli/controlpanel.py
+++ b/tomic/cli/controlpanel.py
@@ -760,7 +760,7 @@ def run_portfolio_menu() -> None:
             logger.info(f"Interpolated CSV saved to {new_path}")
             path = new_path
         data = [
-            normalize_leg({k.lower(): v for k, v in rec.items()})
+            normalize_leg(rec)
             for rec in df.to_dict(orient="records")
         ]
         symbol = str(SESSION_STATE.get("symbol", ""))

--- a/tomic/strategy_candidates.py
+++ b/tomic/strategy_candidates.py
@@ -363,20 +363,25 @@ def _metrics(
     if min_vol > 0 or min_oi > 0:
         low_liq: List[str] = []
         for leg in legs:
+            vol_raw = leg.get("volume")
             try:
-                vol = float(leg.get("volume") or 0)
+                vol = float(vol_raw) if vol_raw not in (None, "") else None
             except Exception:
-                vol = 0.0
+                vol = None
+            oi_raw = leg.get("open_interest")
             try:
-                oi = float(leg.get("open_interest") or 0)
+                oi = float(oi_raw) if oi_raw not in (None, "") else None
             except Exception:
-                oi = 0.0
+                oi = None
             exp = leg.get("expiry") or leg.get("expiration")
             strike = leg.get("strike")
             if isinstance(strike, float) and strike.is_integer():
                 strike = int(strike)
-            if (min_vol > 0 and vol < min_vol) or (min_oi > 0 and oi < min_oi):
-                low_liq.append(f"{strike} [{vol}, {oi}, {exp}]")
+            if (
+                (min_vol > 0 and vol is not None and vol < min_vol)
+                or (min_oi > 0 and oi is not None and oi < min_oi)
+            ):
+                low_liq.append(f"{strike} [{vol or 0}, {oi or 0}, {exp}]")
         if low_liq:
             logger.info(
                 f"[{strategy}] Onvoldoende volume/open interest voor strikes {', '.join(low_liq)}"

--- a/tomic/utils.py
+++ b/tomic/utils.py
@@ -204,6 +204,16 @@ _NUMERIC_KEYS = {
     "open_interest",
 }
 
+# Legacy keys that may appear in CSVs without underscores or in other forms
+LEGACY_LEG_KEYS = {
+    "openinterest": "open_interest",
+    "impliedvolatility": "iv",
+    "implied_volatility": "iv",
+    "delta": "delta",  # redundant but explicit
+    "vega": "vega",
+    "theta": "theta",
+}
+
 
 def normalize_leg(leg: dict) -> dict:
     """Cast numeric fields in ``leg`` to ``float`` if possible.
@@ -213,6 +223,7 @@ def normalize_leg(leg: dict) -> dict:
 
     for key in list(leg.keys()):
         canonical = re.sub(r"(?<!^)(?=[A-Z])", "_", key).lower()
+        canonical = LEGACY_LEG_KEYS.get(canonical, canonical)
         val = leg[key]
         if canonical in _NUMERIC_KEYS:
             leg[canonical] = parse_euro_float(val)


### PR DESCRIPTION
## Summary
- preserve original column names when normalizing legs in the control panel
- map legacy leg keys like `openinterest` and `ImpliedVolatility` to their canonical names
- skip liquidity checks when volume/open interest data is absent
- test normalization of legacy open interest field

## Testing
- `pytest tests/analysis/test_calendar_metrics.py::test_calendar_metrics_allows_negative_credit tests/analysis/test_metrics.py::test_metrics_iron_condor tests/analysis/test_metrics.py::test_metrics_atm_iron_butterfly tests/analysis/test_metrics.py::test_metrics_bull_put_spread tests/analysis/test_metrics.py::test_metrics_short_call_spread tests/analysis/test_metrics.py::test_metrics_naked_put tests/analysis/test_metrics.py::test_metrics_backspread_put tests/analysis/test_ratio_spread_metrics.py::test_ratio_spread_metrics_quantities tests/helpers/test_utils.py::test_normalize_leg_openinterest -q`

------
https://chatgpt.com/codex/tasks/task_b_689458350530832eba7de8fe2a3af016