### PR TITLE
Include option expiry in overview

### DIFF
--- a/tomic/cli/controlpanel.py
+++ b/tomic/cli/controlpanel.py
@@ -1024,7 +1024,7 @@ def run_portfolio_menu() -> None:
                     warn_edge = False
                     for prop in proposals:
                         legs_desc = "; ".join(
-                            f"{'S' if leg.get('position',0)<0 else 'L'}{leg.get('type')}{leg.get('strike')}"
+                            f"{'S' if leg.get('position',0)<0 else 'L'}{leg.get('type')}{leg.get('strike')} {leg.get('expiry', '?')}"
                             for leg in prop.legs
                         )
                         for leg in prop.legs:


### PR DESCRIPTION
## Summary
- display each leg's expiry in the proposal overview

## Testing
- `pytest` *(fails: tests/analysis/test_liquidity_filter.py::test_metrics_rejects_low_liquidity)*

------
https://chatgpt.com/codex/tasks/task_b_689474daded8832ea4d84a7aa7763040