### PR TITLE
feat: refresh spot price from polygon

### DIFF
--- a/tests/cli/test_csv_quality_integration.py
+++ b/tests/cli/test_csv_quality_integration.py
@@ -23,6 +23,7 @@ def test_process_chain_respects_quality(tmp_path, monkeypatch):
     monkeypatch.setattr(mod.cfg, "get", lambda name, default=None: 70 if name == "CSV_MIN_QUALITY" else default)
     monkeypatch.setattr(mod.cfg, "_load_yaml", lambda p: {})
     monkeypatch.setattr(mod, "load_strike_config", lambda strat, data: {})
+    monkeypatch.setattr(mod, "refresh_spot_price", lambda s: None)
     monkeypatch.setattr(mod, "_load_spot_from_metrics", lambda d, s: None)
     monkeypatch.setattr(mod, "_load_latest_close", lambda s: (100.0, "20240101"))
 

--- a/tomic/polygon_client.py
+++ b/tomic/polygon_client.py
@@ -126,3 +126,15 @@ class PolygonClient(MarketDataProvider):
         results = data.get("results") or []
         spot = results[0].get("c") if results else None
         return {"spot_price": spot}
+
+    def fetch_spot_price(self, symbol: str) -> float | None:
+        """Return the delayed last trade price for ``symbol``."""
+        data = self._request(f"v2/last/trade/{symbol.upper()}")
+        # Polygon sometimes uses "results" with key "p" for price or
+        # "last" with key "price" – handle both formats.
+        result = data.get("results") or data.get("last") or {}
+        price = result.get("p") or result.get("price")
+        try:
+            return float(price) if price is not None else None
+        except Exception:
+            return None


### PR DESCRIPTION
## Summary
- add PolygonClient.fetch_spot_price for last trade quotes
- cache spot prices via refresh_spot_price helper
- refresh spot price before proposal generation

## Testing
- `pytest tests/cli/test_controlpanel_proposals.py tests/cli/test_csv_quality_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689c3f6aa1f4832e8a6999903454a6ca