### PR TITLE
Display spot price before showing strategy score weights

### DIFF
--- a/tomic/cli/controlpanel.py
+++ b/tomic/cli/controlpanel.py
@@ -1065,6 +1065,10 @@ def run_portfolio_menu() -> None:
                 if spot_for_strats is None:
                     spot_for_strats, _ = _load_latest_close(symbol)
                 SESSION_STATE["spot_price"] = spot_for_strats
+                if spot_for_strats is not None:
+                    print(f"Spotprice: {spot_for_strats:.2f}")
+                else:
+                    print("Spotprice: n/a")
                 proposals, reason = generate_strategy_candidates(
                     symbol,
                     strat,


### PR DESCRIPTION
## Summary
- Print current spot price after storing it in session state
- Show `Spotprice: n/a` when spot price is unavailable

## Testing
- `pytest -q` *(fails: tests/api/test_market_client.py::test_security_def_option_parameter_records_multiplier)*
- `pytest tests/api/test_market_client.py::test_security_def_option_parameter_records_multiplier -q`


------
https://chatgpt.com/codex/tasks/task_b_689cdc6f0464832eb4cb4df22377d041