### PR TITLE
Support scenario-based ROM/EV calculations

### DIFF
--- a/tests/analysis/test_calendar_metrics.py
+++ b/tests/analysis/test_calendar_metrics.py
@@ -23,8 +23,12 @@ def test_calendar_metrics_allows_negative_credit():
             "delta": 0.25,
         },
     ]
-    metrics, reasons = _metrics("calendar", legs)
+    metrics, reasons = _metrics("calendar", legs, 55.0)
     assert metrics is not None
-    assert "ROM kon niet worden berekend" in reasons[0]
+    assert reasons == []
     assert math.isclose(metrics["credit"], -20.0)
     assert metrics["margin"] is not None
+    assert metrics["rom"] is not None
+    assert metrics["ev_pct"] is not None
+    assert metrics["profit_estimated"] is True
+    assert metrics["scenario_info"]["preferred_move"] == "flat"

--- a/tests/analysis/test_metrics.py
+++ b/tests/analysis/test_metrics.py
@@ -66,8 +66,11 @@ def test_metrics_backspread_put():
         {"type": "P", "strike": 45, "expiry": "2025-08-01", "position": 1, "mid": 0.4, "model": 0.4, "delta": -0.15},
         {"type": "P", "strike": 45, "expiry": "2025-08-01", "position": 1, "mid": 0.4, "model": 0.4, "delta": -0.15},
     ]
-    metrics, reasons = _metrics("backspread_put", legs)
+    metrics, reasons = _metrics("backspread_put", legs, 50.0)
     assert metrics is not None
-    assert "ROM kon niet worden berekend" in reasons[0]
+    assert reasons == []
     assert math.isclose(metrics["margin"], 500.0)
     assert metrics["max_loss"] == -500.0
+    assert metrics["rom"] is not None
+    assert metrics["ev_pct"] is not None
+    assert metrics["profit_estimated"] is True

--- a/tests/analysis/test_proposal_engine.py
+++ b/tests/analysis/test_proposal_engine.py
@@ -133,3 +133,4 @@ def test_calendar_profit_estimation(tmp_path: Path) -> None:
     assert cal["profit_estimated"] is True
     assert cal["scenario_info"]["preferred_move"] == "flat"
     assert isinstance(cal["max_profit"], float)
+    assert cal["ROM"] is not None

--- a/tests/analysis/test_ratio_spread_metrics.py
+++ b/tests/analysis/test_ratio_spread_metrics.py
@@ -23,9 +23,13 @@ def test_ratio_spread_metrics_quantities():
             "delta": 0.3,
         },
     ]
-    metrics, reasons = _metrics("ratio_spread", legs)
+    metrics, reasons = _metrics("ratio_spread", legs, 66.0)
     assert metrics is not None
-    assert "ROM kon niet worden berekend" in reasons[0]
+    assert reasons == []
     assert math.isclose(metrics["credit"], 0.0)
     assert math.isclose(metrics["margin"], 200.0)
     assert math.isclose(metrics["max_loss"], -200.0)
+    assert metrics["rom"] is not None
+    assert metrics["ev_pct"] is not None
+    assert metrics["profit_estimated"] is True
+    assert metrics["scenario_info"]["preferred_move"] == "up"

--- a/tests/cli/test_controlpanel_proposals.py
+++ b/tests/cli/test_controlpanel_proposals.py
@@ -241,7 +241,9 @@ def test_export_proposal_json_includes_earnings(monkeypatch, tmp_path):
     mod.SESSION_STATE["strategy"] = "test_strategy"
     mod.SESSION_STATE["spot_price"] = 100.0
 
-    proposal = StrategyProposal(legs=[], credit=0.0)
+    proposal = StrategyProposal(
+        legs=[], credit=0.0, profit_estimated=True, scenario_info={"foo": "bar"}
+    )
 
     def _cell(value):
         return (lambda x: lambda: x)(value).__closure__[0]
@@ -274,3 +276,5 @@ def test_export_proposal_json_includes_earnings(monkeypatch, tmp_path):
     assert files, "export file not created"
     data = json.loads(files[0].read_text())
     assert data["next_earnings_date"] == "2030-01-01"
+    assert data["metrics"]["profit_estimated"] is True
+    assert data["metrics"]["scenario_info"] == {"foo": "bar"}

--- a/tomic/cli/controlpanel.py
+++ b/tomic/cli/controlpanel.py
@@ -1358,6 +1358,13 @@ def run_portfolio_menu() -> None:
             writer.writerow([])
             writer.writerow(["credit", proposal.credit])
             writer.writerow(["max_loss", proposal.max_loss])
+            writer.writerow(["profit_estimated", proposal.profit_estimated])
+            writer.writerow([
+                "scenario_info",
+                json.dumps(proposal.scenario_info)
+                if proposal.scenario_info is not None
+                else None,
+            ])
             if proposal.breakevens:
                 writer.writerow(["breakevens", *proposal.breakevens])
         print(f"✅ Voorstel opgeslagen in: {path.resolve()}")
@@ -1466,6 +1473,8 @@ def run_portfolio_menu() -> None:
                 else "unlimited",
                 "breakevens": proposal.breakevens or [],
                 "score": proposal.score,
+                "profit_estimated": proposal.profit_estimated,
+                "scenario_info": proposal.scenario_info,
                 "missing_data": {
                     "missing_bidask": any(
                         (

--- a/tomic/strategies/atm_iron_butterfly.py
+++ b/tomic/strategies/atm_iron_butterfly.py
@@ -124,7 +124,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             ]
             if any(l is None for l in legs):
                 continue
-            metrics, _ = _metrics("atm_iron_butterfly", legs)
+            metrics, _ = _metrics("atm_iron_butterfly", legs, spot)
             if metrics and passes_risk(metrics):
                 proposals.append(StrategyProposal(legs=legs, **metrics))
             if len(proposals) >= 5:

--- a/tomic/strategies/backspread_put.py
+++ b/tomic/strategies/backspread_put.py
@@ -126,7 +126,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
                 legs = [make_leg(short_opt, -1), make_leg(long_opt, 2)]
                 if any(l is None for l in legs):
                     continue
-                metrics, _ = _metrics("backspread_put", legs)
+                        metrics, _ = _metrics("backspread_put", legs, spot)
                 if metrics and passes_risk(metrics):
                     if _validate_ratio("backspread_put", legs, metrics.get("credit", 0.0)):
                         proposals.append(StrategyProposal(legs=legs, **metrics))

--- a/tomic/strategies/calendar.py
+++ b/tomic/strategies/calendar.py
@@ -95,7 +95,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
                 ):
                     leg["edge"] = leg["model"] - leg["mid"]
             legs = [normalize_leg(l) for l in legs]
-            metrics, _ = _metrics("calendar", legs)
+            metrics, _ = _metrics("calendar", legs, spot)
             if not metrics:
                 continue
             if min_rr > 0:

--- a/tomic/strategies/iron_condor.py
+++ b/tomic/strategies/iron_condor.py
@@ -124,7 +124,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
         ]
         if any(l is None for l in legs):
             continue
-        metrics, _ = _metrics("iron_condor", legs)
+            metrics, _ = _metrics("iron_condor", legs, spot)
         if metrics and passes_risk(metrics):
             proposals.append(StrategyProposal(legs=legs, **metrics))
     proposals.sort(key=lambda p: p.score or 0, reverse=True)

--- a/tomic/strategies/naked_put.py
+++ b/tomic/strategies/naked_put.py
@@ -102,7 +102,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
                 leg = make_leg(opt, -1)
                 if leg is None:
                     continue
-                metrics, _ = _metrics("naked_put", [leg])
+                    metrics, _ = _metrics("naked_put", [leg], spot)
                 if metrics and passes_risk(metrics):
                     proposals.append(StrategyProposal(legs=[leg], **metrics))
                 if len(proposals) >= 5:

--- a/tomic/strategies/ratio_spread.py
+++ b/tomic/strategies/ratio_spread.py
@@ -147,7 +147,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             legs = [make_leg(short_opt, -1), make_leg(long_opt, 2)]
             if any(l is None for l in legs):
                 continue
-            metrics, _ = _metrics("ratio_spread", legs)
+            metrics, _ = _metrics("ratio_spread", legs, spot)
             if metrics and passes_risk(metrics):
                 if _validate_ratio("ratio_spread", legs, metrics.get("credit", 0.0)):
                     proposals.append(StrategyProposal(legs=legs, **metrics))

--- a/tomic/strategies/short_call_spread.py
+++ b/tomic/strategies/short_call_spread.py
@@ -122,7 +122,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             legs = [make_leg(short_opt, -1), make_leg(long_opt, 1)]
             if any(l is None for l in legs):
                 continue
-            metrics, _ = _metrics("short_call_spread", legs)
+            metrics, _ = _metrics("short_call_spread", legs, spot)
             if metrics and passes_risk(metrics):
                 proposals.append(StrategyProposal(legs=legs, **metrics))
             if len(proposals) >= 5:

--- a/tomic/strategies/short_put_spread.py
+++ b/tomic/strategies/short_put_spread.py
@@ -122,7 +122,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             legs = [make_leg(short_opt, -1), make_leg(long_opt, 1)]
             if any(l is None for l in legs):
                 continue
-            metrics, _ = _metrics("bull put spread", legs)
+            metrics, _ = _metrics("bull put spread", legs, spot)
             if metrics and passes_risk(metrics):
                 proposals.append(StrategyProposal(legs=legs, **metrics))
             if len(proposals) >= 5:


### PR DESCRIPTION
## Summary
- allow ROM and EV when profit is estimated via scenarios
- include `profit_estimated` and `scenario_info` in metrics and exports
- wire strategy generators to pass spot for scenario estimation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_b_689cf2c4a87c832ebce989454b856155