### PR TITLE
Track mid price fallbacks to close or parity

### DIFF
--- a/tests/analysis/test_metrics.py
+++ b/tests/analysis/test_metrics.py
@@ -74,3 +74,95 @@ def test_metrics_backspread_put():
     assert metrics["rom"] is not None
     assert metrics["ev_pct"] is not None
     assert metrics["profit_estimated"] is True
+
+
+def test_metrics_reports_close_fallback():
+    legs = [
+        {
+            "type": "C",
+            "strike": 60,
+            "expiry": "2025-08-01",
+            "position": -1,
+            "mid": 1.2,
+            "model": 1.2,
+            "delta": 0.2,
+            "mid_fallback": "close",
+        },
+        {
+            "type": "C",
+            "strike": 65,
+            "expiry": "2025-08-01",
+            "position": 1,
+            "mid": 0.4,
+            "model": 0.4,
+            "delta": 0.1,
+        },
+        {
+            "type": "P",
+            "strike": 50,
+            "expiry": "2025-08-01",
+            "position": -1,
+            "mid": 1.0,
+            "model": 1.0,
+            "delta": -0.2,
+        },
+        {
+            "type": "P",
+            "strike": 45,
+            "expiry": "2025-08-01",
+            "position": 1,
+            "mid": 0.3,
+            "model": 0.3,
+            "delta": -0.1,
+        },
+    ]
+    metrics, reasons = _metrics("iron_condor", legs)
+    assert metrics is not None
+    assert metrics.get("fallback") == "close"
+    assert "fallback naar close gebruikt voor midprijs" in reasons
+
+
+def test_metrics_reports_parity_fallback():
+    legs = [
+        {
+            "type": "C",
+            "strike": 60,
+            "expiry": "2025-08-01",
+            "position": -1,
+            "mid": 1.2,
+            "model": 1.2,
+            "delta": 0.2,
+            "mid_fallback": "parity",
+        },
+        {
+            "type": "C",
+            "strike": 65,
+            "expiry": "2025-08-01",
+            "position": 1,
+            "mid": 0.4,
+            "model": 0.4,
+            "delta": 0.1,
+        },
+        {
+            "type": "P",
+            "strike": 50,
+            "expiry": "2025-08-01",
+            "position": -1,
+            "mid": 1.0,
+            "model": 1.0,
+            "delta": -0.2,
+        },
+        {
+            "type": "P",
+            "strike": 45,
+            "expiry": "2025-08-01",
+            "position": 1,
+            "mid": 0.3,
+            "model": 0.3,
+            "delta": -0.1,
+        },
+    ]
+    metrics, reasons = _metrics("iron_condor", legs)
+    assert metrics is not None
+    assert metrics.get("fallback") == "parity"
+    assert "fallback naar close gebruikt voor midprijs" not in reasons

--- a/tests/analysis/test_strategy_candidates_new.py
+++ b/tests/analysis/test_strategy_candidates_new.py
@@ -182,6 +182,7 @@ def test_parity_mid_used_for_missing_bidask(monkeypatch):
     assert sc_leg is not None
     assert sc_leg.get("mid_from_parity") is True
     assert sc_leg.get("mid") is not None
+    assert sc_leg.get("mid_fallback") == "parity"
 
 
 def test_metrics_black_scholes_fallback(monkeypatch):

--- a/tomic/strategies/atm_iron_butterfly.py
+++ b/tomic/strategies/atm_iron_butterfly.py
@@ -38,12 +38,23 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
     min_rr = float(strat_cfg.get("min_risk_reward", 0.0))
 
     def make_leg(opt: Dict[str, Any], position: int) -> Dict[str, Any] | None:
+        bid = opt.get("bid")
+        ask = opt.get("ask")
         mid = get_option_mid_price(opt)
+        used_close = False
         if mid is None:
             try:
                 close_val = float(opt.get("close"))
                 if close_val > 0:
                     mid = close_val
+                    used_close = True
+            except Exception:
+                pass
+        else:
+            try:
+                close_val = float(opt.get("close"))
+                if mid == close_val:
+                    used_close = True
             except Exception:
                 pass
         if mid is None:
@@ -55,8 +66,8 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             "spot": spot,
             "iv": opt.get("iv"),
             "delta": opt.get("delta"),
-            "bid": opt.get("bid"),
-            "ask": opt.get("ask"),
+            "bid": bid,
+            "ask": ask,
             "mid": mid,
             "edge": opt.get("edge"),
             "model": opt.get("model"),
@@ -64,6 +75,15 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             "open_interest": opt.get("open_interest"),
             "position": position,
         }
+        def _missing(val: Any) -> bool:
+            try:
+                return float(val) <= 0
+            except Exception:
+                return True
+        if opt.get("mid_from_parity"):
+            leg["mid_fallback"] = "parity"
+        elif used_close and (_missing(bid) or _missing(ask)):
+            leg["mid_fallback"] = "close"
         try:
             opt_type = (opt.get("type") or opt.get("right") or "").upper()[0]
             strike = float(opt["strike"])

--- a/tomic/strategies/backspread_put.py
+++ b/tomic/strategies/backspread_put.py
@@ -39,12 +39,23 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
     min_rr = float(strat_cfg.get("min_risk_reward", 0.0))
 
     def make_leg(opt: Dict[str, Any], position: int) -> Dict[str, Any] | None:
+        bid = opt.get("bid")
+        ask = opt.get("ask")
         mid = get_option_mid_price(opt)
+        used_close = False
         if mid is None:
             try:
                 close_val = float(opt.get("close"))
                 if close_val > 0:
                     mid = close_val
+                    used_close = True
+            except Exception:
+                pass
+        else:
+            try:
+                close_val = float(opt.get("close"))
+                if mid == close_val:
+                    used_close = True
             except Exception:
                 pass
         if mid is None:
@@ -56,8 +67,8 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             "spot": spot,
             "iv": opt.get("iv"),
             "delta": opt.get("delta"),
-            "bid": opt.get("bid"),
-            "ask": opt.get("ask"),
+            "bid": bid,
+            "ask": ask,
             "mid": mid,
             "edge": opt.get("edge"),
             "model": opt.get("model"),
@@ -65,6 +76,15 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             "open_interest": opt.get("open_interest"),
             "position": position,
         }
+        def _missing(val: Any) -> bool:
+            try:
+                return float(val) <= 0
+            except Exception:
+                return True
+        if opt.get("mid_from_parity"):
+            leg["mid_fallback"] = "parity"
+        elif used_close and (_missing(bid) or _missing(ask)):
+            leg["mid_fallback"] = "close"
         try:
             opt_type = (opt.get("type") or opt.get("right") or "").upper()[0]
             strike = float(opt["strike"])

--- a/tomic/strategies/iron_condor.py
+++ b/tomic/strategies/iron_condor.py
@@ -41,12 +41,23 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
     min_rr = float(strat_cfg.get("min_risk_reward", 0.0))
 
     def make_leg(opt: Dict[str, Any], position: int) -> Dict[str, Any] | None:
+        bid = opt.get("bid")
+        ask = opt.get("ask")
         mid = get_option_mid_price(opt)
+        used_close = False
         if mid is None:
             try:
                 close_val = float(opt.get("close"))
                 if close_val > 0:
                     mid = close_val
+                    used_close = True
+            except Exception:
+                pass
+        else:
+            try:
+                close_val = float(opt.get("close"))
+                if mid == close_val:
+                    used_close = True
             except Exception:
                 pass
         if mid is None:
@@ -58,8 +69,8 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             "spot": spot,
             "iv": opt.get("iv"),
             "delta": opt.get("delta"),
-            "bid": opt.get("bid"),
-            "ask": opt.get("ask"),
+            "bid": bid,
+            "ask": ask,
             "mid": mid,
             "edge": opt.get("edge"),
             "model": opt.get("model"),
@@ -67,6 +78,15 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             "open_interest": opt.get("open_interest"),
             "position": position,
         }
+        def _missing(val: Any) -> bool:
+            try:
+                return float(val) <= 0
+            except Exception:
+                return True
+        if opt.get("mid_from_parity"):
+            leg["mid_fallback"] = "parity"
+        elif used_close and (_missing(bid) or _missing(ask)):
+            leg["mid_fallback"] = "close"
         try:
             opt_type = (opt.get("type") or opt.get("right") or "").upper()[0]
             strike = float(opt["strike"])

--- a/tomic/strategies/naked_put.py
+++ b/tomic/strategies/naked_put.py
@@ -35,12 +35,23 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
     min_rr = float(strat_cfg.get("min_risk_reward", 0.0))
 
     def make_leg(opt: Dict[str, Any], position: int) -> Dict[str, Any] | None:
+        bid = opt.get("bid")
+        ask = opt.get("ask")
         mid = get_option_mid_price(opt)
+        used_close = False
         if mid is None:
             try:
                 close_val = float(opt.get("close"))
                 if close_val > 0:
                     mid = close_val
+                    used_close = True
+            except Exception:
+                pass
+        else:
+            try:
+                close_val = float(opt.get("close"))
+                if mid == close_val:
+                    used_close = True
             except Exception:
                 pass
         if mid is None:
@@ -52,8 +63,8 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             "spot": spot,
             "iv": opt.get("iv"),
             "delta": opt.get("delta"),
-            "bid": opt.get("bid"),
-            "ask": opt.get("ask"),
+            "bid": bid,
+            "ask": ask,
             "mid": mid,
             "edge": opt.get("edge"),
             "model": opt.get("model"),
@@ -61,6 +72,15 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             "open_interest": opt.get("open_interest"),
             "position": position,
         }
+        def _missing(val: Any) -> bool:
+            try:
+                return float(val) <= 0
+            except Exception:
+                return True
+        if opt.get("mid_from_parity"):
+            leg["mid_fallback"] = "parity"
+        elif used_close and (_missing(bid) or _missing(ask)):
+            leg["mid_fallback"] = "close"
         try:
             opt_type = (opt.get("type") or opt.get("right") or "").upper()[0]
             strike = float(opt["strike"])

--- a/tomic/strategies/short_call_spread.py
+++ b/tomic/strategies/short_call_spread.py
@@ -38,12 +38,23 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
     min_rr = float(strat_cfg.get("min_risk_reward", 0.0))
 
     def make_leg(opt: Dict[str, Any], position: int) -> Dict[str, Any] | None:
+        bid = opt.get("bid")
+        ask = opt.get("ask")
         mid = get_option_mid_price(opt)
+        used_close = False
         if mid is None:
             try:
                 close_val = float(opt.get("close"))
                 if close_val > 0:
                     mid = close_val
+                    used_close = True
+            except Exception:
+                pass
+        else:
+            try:
+                close_val = float(opt.get("close"))
+                if mid == close_val:
+                    used_close = True
             except Exception:
                 pass
         if mid is None:
@@ -55,8 +66,8 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             "spot": spot,
             "iv": opt.get("iv"),
             "delta": opt.get("delta"),
-            "bid": opt.get("bid"),
-            "ask": opt.get("ask"),
+            "bid": bid,
+            "ask": ask,
             "mid": mid,
             "edge": opt.get("edge"),
             "model": opt.get("model"),
@@ -64,6 +75,15 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             "open_interest": opt.get("open_interest"),
             "position": position,
         }
+        def _missing(val: Any) -> bool:
+            try:
+                return float(val) <= 0
+            except Exception:
+                return True
+        if opt.get("mid_from_parity"):
+            leg["mid_fallback"] = "parity"
+        elif used_close and (_missing(bid) or _missing(ask)):
+            leg["mid_fallback"] = "close"
         try:
             opt_type = (opt.get("type") or opt.get("right") or "").upper()[0]
             strike = float(opt["strike"])

--- a/tomic/strategies/short_put_spread.py
+++ b/tomic/strategies/short_put_spread.py
@@ -38,12 +38,23 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
     min_rr = float(strat_cfg.get("min_risk_reward", 0.0))
 
     def make_leg(opt: Dict[str, Any], position: int) -> Dict[str, Any] | None:
+        bid = opt.get("bid")
+        ask = opt.get("ask")
         mid = get_option_mid_price(opt)
+        used_close = False
         if mid is None:
             try:
                 close_val = float(opt.get("close"))
                 if close_val > 0:
                     mid = close_val
+                    used_close = True
+            except Exception:
+                pass
+        else:
+            try:
+                close_val = float(opt.get("close"))
+                if mid == close_val:
+                    used_close = True
             except Exception:
                 pass
         if mid is None:
@@ -55,8 +66,8 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             "spot": spot,
             "iv": opt.get("iv"),
             "delta": opt.get("delta"),
-            "bid": opt.get("bid"),
-            "ask": opt.get("ask"),
+            "bid": bid,
+            "ask": ask,
             "mid": mid,
             "edge": opt.get("edge"),
             "model": opt.get("model"),
@@ -64,6 +75,15 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             "open_interest": opt.get("open_interest"),
             "position": position,
         }
+        def _missing(val: Any) -> bool:
+            try:
+                return float(val) <= 0
+            except Exception:
+                return True
+        if opt.get("mid_from_parity"):
+            leg["mid_fallback"] = "parity"
+        elif used_close and (_missing(bid) or _missing(ask)):
+            leg["mid_fallback"] = "close"
         try:
             opt_type = (opt.get("type") or opt.get("right") or "").upper()[0]
             strike = float(opt["strike"])

--- a/tomic/strategy_candidates.py
+++ b/tomic/strategy_candidates.py
@@ -426,7 +426,8 @@ def _metrics(
             f"[{strategy}] Ontbrekende bid/ask-data voor strikes {','.join(missing_mid)}"
         )
         reasons.append("ontbrekende bid/ask-data")
-    if any(leg.get("mid_fallback") == "close" for leg in legs):
+    fallbacks = {leg.get("mid_fallback") for leg in legs if leg.get("mid_fallback")}
+    if "close" in fallbacks:
         reasons.append("fallback naar close gebruikt voor midprijs")
     net_credit = credit_short - debit_long
     strikes = "/".join(str(l.get("strike")) for l in legs)
@@ -523,8 +524,8 @@ def _metrics(
         "profit_estimated": profit_estimated,
         "scenario_info": scenario_info,
     }
-    if any(leg.get("mid_fallback") == "close" for leg in legs):
-        result["fallback"] = "close"
+    if fallbacks:
+        result["fallback"] = ",".join(sorted(fallbacks))
     return result, reasons
 
 


### PR DESCRIPTION
## Summary
- record whether leg mid prices fall back to close or put-call parity across strategies
- report fallback sources in metrics output and reasons
- extend tests to cover close and parity fallbacks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689dda0a64e0832eb1db7d9f41dba8ea