### PR TITLE
Refine iron condor margin calculation

### DIFF
--- a/tests/analysis/test_metrics.py
+++ b/tests/analysis/test_metrics.py
@@ -13,10 +13,10 @@ def test_metrics_iron_condor():
     assert reasons == []
     assert metrics is not None
     assert math.isclose(metrics["credit"], 150.0)
-    assert math.isclose(metrics["margin"], 500.0)
+    assert math.isclose(metrics["margin"], 350.0)
     assert metrics["rom"] is not None
-    assert math.isclose(metrics["ev_pct"], 10.0)
-    assert math.isclose(metrics["score"], 41.0)
+    assert math.isclose(metrics["ev_pct"], 14.285714285714285)
+    assert math.isclose(metrics["score"], 48.29)
 
 
 def test_metrics_atm_iron_butterfly():

--- a/tests/analysis/test_metrics_calc.py
+++ b/tests/analysis/test_metrics_calc.py
@@ -81,7 +81,7 @@ def test_calculate_credit_and_margin_condor():
     credit = calculate_credit(legs)
     assert math.isclose(credit, 224.0)
     margin = calculate_margin("iron_condor", legs, net_cashflow=credit / 100)
-    assert math.isclose(margin, 500.0)
+    assert math.isclose(margin, 276.0)
 
 
 def test_calculate_payoff_at_spot_naked_put():

--- a/tests/analysis/test_proposal_engine.py
+++ b/tests/analysis/test_proposal_engine.py
@@ -117,7 +117,7 @@ def test_condor_margin(tmp_path: Path) -> None:
     exposure = {"Delta": 0, "Theta": 0, "Vega": 80, "Gamma": 0}
     props = suggest_strategies("XYZ", chain, exposure, spot_price=100.0)
     condor = next(p for p in props if p["strategy"] == "iron_condor")
-    assert math.isclose(condor["margin"], 500.0)
+    assert math.isclose(condor["margin"], 430.0)
     assert math.isclose(
         condor["ROM"], condor["max_profit"] / condor["margin"] * 100
     )

--- a/tomic/metrics.py
+++ b/tomic/metrics.py
@@ -244,7 +244,7 @@ def calculate_margin(
         if width <= 0:
             logger.warning("iron_condor wing width is non-positive")
             return None
-        return width * 100
+        return max(width * 100 - net_cashflow * 100, 0.0)
 
     if strat in {"calendar"}:
         if len(legs) != 2:


### PR DESCRIPTION
## Summary
- subtract strategy credit from iron condor and ATM iron butterfly margin
- update margin expectations in tests

## Testing
- `pytest tests/analysis/test_metrics_calc.py tests/analysis/test_metrics.py tests/analysis/test_proposal_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689dddd32988832e97181b5ac44aaf61