### PR TITLE
Require positive credit for naked puts

### DIFF
--- a/tests/analysis/test_metrics.py
+++ b/tests/analysis/test_metrics.py
@@ -60,6 +60,15 @@ def test_metrics_naked_put():
     assert "negatieve EV of score" in reasons
 
 
+def test_metrics_naked_put_requires_positive_credit():
+    legs = [
+        {"type": "P", "strike": 50, "expiry": "2025-08-01", "position": 1, "mid": 1.0, "model": 1.0, "delta": -0.3},
+    ]
+    metrics, reasons = _metrics("naked_put", legs)
+    assert metrics is None
+    assert reasons == ["negatieve credit"]
+
+
 def test_metrics_backspread_put():
     legs = [
         {"type": "P", "strike": 50, "expiry": "2025-08-01", "position": -1, "mid": 0.8, "model": 0.8, "delta": -0.3},

--- a/tomic/strategy_candidates.py
+++ b/tomic/strategy_candidates.py
@@ -37,6 +37,7 @@ STRATEGIES_THAT_REQUIRE_POSITIVE_CREDIT = {
     "short_call_spread",
     "iron_condor",
     "atm_iron_butterfly",
+    "naked_put",
 }
 
 


### PR DESCRIPTION
## Summary
- ensure naked put strategies yield a positive net credit
- verify naked puts with non-positive credit are rejected

## Testing
- `pytest tests/analysis/test_metrics.py tests/analysis/test_calendar_metrics.py`

------
https://chatgpt.com/codex/tasks/task_b_689e35501da0832e89044e72fddbd157