### PR TITLE
Centralize thresholds via criteria config

### DIFF
--- a/criteria.yaml
+++ b/criteria.yaml
@@ -1,0 +1,23 @@
+strike:
+  delta_min: -0.8
+  delta_max: 0.8
+  min_rom: 0.0
+  min_edge: 0.0
+  min_pos: 0.0
+  min_ev: 0.0
+  skew_min: -0.1
+  skew_max: 0.1
+  term_min: -0.2
+  term_max: 0.2
+  max_gamma: null
+  max_vega: null
+  min_theta: null
+strategy:
+  score_weight_rom: 0.5
+  score_weight_pos: 0.3
+  score_weight_ev: 0.2
+market_data:
+  min_option_volume: 0
+  min_option_open_interest: 0
+alerts:
+  nearest_strike_tolerance_percent: 2.0

--- a/tests/analysis/test_nearest_strike.py
+++ b/tests/analysis/test_nearest_strike.py
@@ -1,4 +1,5 @@
 from tomic.strategy_candidates import _build_strike_map, _nearest_strike
+from tomic.criteria import AlertCriteria, CriteriaConfig, load_criteria
 
 
 def test_nearest_strike_simple():
@@ -23,15 +24,15 @@ def test_nearest_strike_tolerance():
     assert res.matched is None
 
 
-def test_nearest_strike_uses_config(monkeypatch):
+def test_nearest_strike_uses_config():
     chain = [{"expiry": "20250101", "strike": 100, "type": "c"}]
     m = _build_strike_map(chain)
-
-    def fake_cfg_get(key, default=None):
-        if key == "NEAREST_STRIKE_TOLERANCE_PERCENT":
-            return 5.0
-        return default
-
-    monkeypatch.setattr("tomic.strategy_candidates.cfg_get", fake_cfg_get)
-    res = _nearest_strike(m, "20250101", "c", 104)
+    base = load_criteria()
+    criteria = CriteriaConfig(
+        strike=base.strike,
+        strategy=base.strategy,
+        market_data=base.market_data,
+        alerts=AlertCriteria(nearest_strike_tolerance_percent=5.0),
+    )
+    res = _nearest_strike(m, "20250101", "c", 104, criteria=criteria)
     assert res.matched == 100

--- a/tests/analysis/test_scenario_metrics.py
+++ b/tests/analysis/test_scenario_metrics.py
@@ -1,6 +1,7 @@
 import pytest
 from tomic.strategy_candidates import _metrics
 from tomic.logutils import logger
+from tomic.criteria import load_criteria
 
 
 SCENARIOS = [
@@ -97,7 +98,7 @@ def test_scenario_metrics(strategy, legs, spot, label):
 
     buf = StringIO()
     handler_id = logger.add(buf, level="INFO")
-    metrics, reasons = _metrics(strategy, legs, spot)
+    metrics, reasons = _metrics(strategy, legs, spot, criteria=load_criteria())
     logger.remove(handler_id)
     assert metrics is not None
     assert reasons == []
@@ -115,7 +116,6 @@ def test_missing_scenario(monkeypatch):
             return {}
         return default
 
-    monkeypatch.setattr("tomic.strategy_candidates.cfg_get", fake_cfg_get)
     monkeypatch.setattr("tomic.metrics.cfg_get", fake_cfg_get)
 
     legs = [
@@ -139,7 +139,7 @@ def test_missing_scenario(monkeypatch):
         },
     ]
 
-    metrics, reasons = _metrics("calendar", legs, 55.0)
+    metrics, reasons = _metrics("calendar", legs, 55.0, criteria=load_criteria())
     assert metrics is not None
     assert metrics.get("ev") is None
     assert metrics.get("rom") is None

--- a/tests/analysis/test_strike_selector.py
+++ b/tests/analysis/test_strike_selector.py
@@ -1,24 +1,28 @@
 from importlib import reload
 
 from tomic import strike_selector as ss
+from tomic.criteria import StrikeCriteria, load_criteria
 
 
 def test_selector_filters(monkeypatch):
-    conf = {
-        "DELTA_MIN": -0.5,
-        "DELTA_MAX": 0.5,
-        "STRIKE_MIN_ROM": 10,
-        "STRIKE_MIN_EDGE": 0.2,
-        "STRIKE_MIN_POS": 60,
-        "STRIKE_MIN_EV": 0,
-        "STRIKE_SKEW_MIN": -0.1,
-        "STRIKE_SKEW_MAX": 0.1,
-        "STRIKE_TERM_MIN": -0.2,
-        "STRIKE_TERM_MAX": 0.2,
-    }
-    monkeypatch.setattr(ss, "cfg_get", lambda name, default=None: conf.get(name, default))
-    reload(ss)
-    selector = ss.StrikeSelector()
+    base = load_criteria()
+    criteria = base.model_copy(
+        update={
+            "strike": StrikeCriteria(
+                delta_min=-0.5,
+                delta_max=0.5,
+                min_rom=10,
+                min_edge=0.2,
+                min_pos=60,
+                min_ev=0,
+                skew_min=-0.1,
+                skew_max=0.1,
+                term_min=-0.2,
+                term_max=0.2,
+            )
+        }
+    )
+    selector = ss.StrikeSelector(criteria=criteria)
     opts = [
         {
             "expiry": "20250101",

--- a/tomic/criteria.py
+++ b/tomic/criteria.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel
+
+from .config import _load_yaml  # reuse YAML loader
+
+
+class StrikeCriteria(BaseModel):
+    delta_min: float
+    delta_max: float
+    min_rom: float
+    min_edge: float
+    min_pos: float
+    min_ev: float
+    skew_min: float
+    skew_max: float
+    term_min: float
+    term_max: float
+    max_gamma: float | None = None
+    max_vega: float | None = None
+    min_theta: float | None = None
+
+
+class StrategyCriteria(BaseModel):
+    score_weight_rom: float
+    score_weight_pos: float
+    score_weight_ev: float
+
+
+class MarketDataCriteria(BaseModel):
+    min_option_volume: int
+    min_option_open_interest: int
+
+
+class AlertCriteria(BaseModel):
+    nearest_strike_tolerance_percent: float
+
+
+class CriteriaConfig(BaseModel):
+    strike: StrikeCriteria
+    strategy: StrategyCriteria
+    market_data: MarketDataCriteria
+    alerts: AlertCriteria
+
+
+@lru_cache(maxsize=1)
+def load_criteria(path: str | Path | None = None) -> CriteriaConfig:
+    """Load criteria configuration from YAML file once."""
+    base = Path(__file__).resolve().parent.parent
+    cfg_path = Path(path) if path else base / "criteria.yaml"
+    data = _load_yaml(cfg_path) if cfg_path.exists() else {}
+    return CriteriaConfig(**data)


### PR DESCRIPTION
## Summary
- Add `criteria.yaml` to house strike, strategy, market-data, and alert thresholds
- Introduce typed `CriteriaConfig` loader used by strike selection and strategy candidate metrics
- Replace scattered `cfg_get` calls with structured criteria objects and update tests

## Testing
- `pytest tests/analysis/test_strike_selector.py tests/helpers/test_strike_selector.py tests/analysis/test_nearest_strike.py tests/analysis/test_liquidity_filter.py tests/analysis/test_scenario_metrics.py tests/analysis/test_metrics.py`


------
https://chatgpt.com/codex/tasks/task_b_689eca0ed7d8832ea009545e2357ceac