### PR TITLE
feat: add typed rules config

### DIFF
--- a/tomic/__init__.py
+++ b/tomic/__init__.py
@@ -1,1 +1,10 @@
-"""TOMIC core package."""
+"""TOMIC core package.
+
+The project exposes a number of helper modules as well as a validated
+configuration object.  Importing :mod:`tomic` will make the rules
+configuration available as :data:`RULES`.
+"""
+
+from .criteria import RULES
+
+__all__ = ["RULES"]


### PR DESCRIPTION
## Summary
- define Pydantic models for strike, strategy, market-data and alert rules
- load and validate `criteria.yaml` into a single `RULES` object available to consumers
- expose rules config at package root and keep backward compatibility

## Testing
- `pytest tests/test_strike_rules_loader.py tests/analysis/test_liquidity_filter.py tests/analysis/test_nearest_strike.py tests/analysis/test_scenario_metrics.py tests/analysis/test_strike_selector.py tests/helpers/test_strike_selector.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689ecca2fbc8832e97897d784eba5426