### PR TITLE
feat: add dynamic strategy configs

### DIFF
--- a/config/strategies.yaml
+++ b/config/strategies.yaml
@@ -1,0 +1,8 @@
+strategies:
+  iron_condor:
+    min_risk_reward: 1.0
+    strike_to_strategy_config:
+      short_call_multiplier: [1.5, 2.0, 2.5, 3.0, 3.5]
+      short_put_multiplier: [1.5, 2.0, 2.5, 3.0, 3.5]
+      wing_width: 5
+      use_ATR: true

--- a/tests/analysis/test_strategy_dynamic_config.py
+++ b/tests/analysis/test_strategy_dynamic_config.py
@@ -1,0 +1,31 @@
+from tomic.strategy_candidates import generate_strategy_candidates
+from tomic import config
+
+
+def test_generate_candidates_uses_global_config(monkeypatch):
+    chain = [
+        {"expiry": "20250101", "strike": 110, "type": "C", "bid": 1.0, "ask": 1.2, "delta": 0.4, "edge": 0.1, "model": 0, "iv": 0.2},
+        {"expiry": "20250101", "strike": 120, "type": "C", "bid": 0.5, "ask": 0.7, "delta": 0.2, "edge": 0.1, "model": 0, "iv": 0.2},
+        {"expiry": "20250101", "strike": 90, "type": "P", "bid": 1.0, "ask": 1.1, "delta": -0.3, "edge": 0.1, "model": 0, "iv": 0.2},
+        {"expiry": "20250101", "strike": 80, "type": "P", "bid": 0.4, "ask": 0.6, "delta": -0.1, "edge": 0.1, "model": 0, "iv": 0.2},
+    ]
+    monkeypatch.setattr(
+        config,
+        "STRATEGY_CONFIG",
+        {
+            "strategies": {
+                "iron_condor": {
+                    "strike_to_strategy_config": {
+                        "short_call_multiplier": [10],
+                        "short_put_multiplier": [10],
+                        "wing_width": 10,
+                        "use_ATR": False,
+                    }
+                }
+            }
+        },
+    )
+    proposals, reason = generate_strategy_candidates("AAA", "iron_condor", chain, 1.0, None, 100.0)
+    assert reason is None
+    assert isinstance(proposals, list)
+    assert proposals

--- a/tomic/cli/controlpanel.py
+++ b/tomic/cli/controlpanel.py
@@ -835,13 +835,7 @@ def run_portfolio_menu() -> None:
             logger.info(f"- {exp}: {cnt} options in CSV")
 
         strat = str(SESSION_STATE.get("strategy", "")).lower().replace(" ", "_")
-        rules_path = Path(
-            cfg.get("STRIKE_RULES_FILE", "tomic/strike_selection_rules.yaml")
-        )
-        try:
-            config_data = cfg._load_yaml(rules_path)
-        except Exception:
-            config_data = {}
+        config_data = cfg.get("STRATEGY_CONFIG") or {}
         rules = load_strike_config(strat, config_data) if config_data else {}
         dte_range = rules.get("dte_range") or [0, 365]
         try:
@@ -1410,13 +1404,7 @@ def run_portfolio_menu() -> None:
         print(f"✅ Voorstel opgeslagen in: {path.resolve()}")
     def _load_acceptance_criteria(strategy: str) -> dict[str, Any]:
         """Return current acceptance criteria for ``strategy``."""
-        rules_path = Path(
-            cfg.get("STRIKE_RULES_FILE", "tomic/strike_selection_rules.yaml")
-        )
-        try:
-            config_data = cfg._load_yaml(rules_path)
-        except Exception:
-            config_data = {}
+        config_data = cfg.get("STRATEGY_CONFIG") or {}
         rules = load_strike_config(strategy, config_data) if config_data else {}
         try:
             min_rom = float(rules.get("min_rom")) if rules.get("min_rom") is not None else None

--- a/tomic/strategy_candidates.py
+++ b/tomic/strategy_candidates.py
@@ -29,6 +29,7 @@ from .utils import (
 from .logutils import logger, log_combo_evaluation
 from .criteria import CriteriaConfig, load_criteria
 from .strategies import StrategyName
+from .config import get as cfg_get
 
 
 # Strategies that must yield a positive net credit. Calendar spreads are
@@ -576,8 +577,8 @@ def generate_strategy_candidates(
     strategy_type: str,
     option_chain: List[Dict[str, Any]],
     atr: float,
-    config: Dict[str, Any],
-    spot: float | None,
+    config: Dict[str, Any] | None = None,
+    spot: float | None = None,
     *,
     interactive_mode: bool = False,
 ) -> tuple[List[StrategyProposal], str | None]:
@@ -588,7 +589,8 @@ def generate_strategy_candidates(
         mod = __import__(f"tomic.strategies.{strategy_type}", fromlist=["generate"])
     except Exception as e:
         raise ValueError(f"Unknown strategy {strategy_type}") from e
-    return mod.generate(symbol, option_chain, config, spot, atr), None
+    cfg_data = config if config and config.get("strategies") else cfg_get("STRATEGY_CONFIG", {})
+    return mod.generate(symbol, option_chain, cfg_data, spot, atr), None
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- support per-strategy settings via new strategies section in config
- load and pass strategy configs automatically to generators
- test dynamic strategy configuration loading

## Testing
- ⚠️ `pytest tests/analysis/test_strategy_dynamic_config.py::test_generate_candidates_uses_global_config -q` *(no output due to environment issue)*

------
https://chatgpt.com/codex/tasks/task_b_689ed17b4fe0832e8d717de55d47fa75