### PR TITLE
feat: add rules management CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,3 +316,16 @@ pytest tests/
 
 🔍 Debugging
 Om de volledige Polygon API-sleutel te loggen, zet je de omgevingsvariabele `TOMIC_SHOW_POLYGON_KEY=1` voordat je scripts start. De sleutel wordt dan niet gemaskeerd.
+
+📐 Rules configuratie beheren
+Met de ingebouwde CLI kun je de regels in `criteria.yaml` veilig aanpassen:
+
+```bash
+# Toon de actuele configuratie
+tomic rules show
+
+# Valideer wijzigingen en herlaad services
+tomic rules validate path/naar/criteria.yaml --reload
+```
+
+Meer voorbeelden en uitleg staan in `docs/rules_cli.md`.

--- a/docs/rules_cli.md
+++ b/docs/rules_cli.md
@@ -1,0 +1,39 @@
+# Rules configuratie CLI
+
+Deze CLI helpt bij het veilig aanpassen van `criteria.yaml`.
+
+## Configuratie tonen
+
+```
+tomic rules show
+```
+
+Geeft de samengevoegde configuratie weer in JSON-vorm.
+
+## Configuratie valideren
+
+```
+tomic rules validate path/naar/criteria.yaml
+```
+
+Controleert of het YAML-bestand geldig is. Voeg `--reload` toe om na een
+succesvolle validatie de draaiende services te herladen.
+
+```
+tomic rules validate criteria.yaml --reload
+```
+
+## Hot reload
+
+Het `reload`-commando leest de configuratie opnieuw en ververst zowel de
+app-config als de regels:
+
+```
+tomic rules reload
+```
+
+## Tips
+
+- Maak altijd een back-up voordat je het bestand wijzigt.
+- Gebruik `tomic rules validate` om fouten te voorkomen voordat je
+  applicaties start.

--- a/tests/cli/test_rules_cli.py
+++ b/tests/cli/test_rules_cli.py
@@ -1,0 +1,47 @@
+from tomic.cli import rules
+
+VALID = """
+strike:
+  delta_min: -0.8
+  delta_max: 0.8
+  min_rom: 0
+  min_edge: 0
+  min_pos: 0
+  min_ev: 0
+  skew_min: -0.1
+  skew_max: 0.1
+  term_min: -0.2
+  term_max: 0.2
+strategy:
+  score_weight_rom: 0.5
+  score_weight_pos: 0.3
+  score_weight_ev: 0.2
+market_data:
+  min_option_volume: 0
+  min_option_open_interest: 0
+alerts:
+  nearest_strike_tolerance_percent: 1
+  entry_checks: []
+"""
+
+
+def test_show(capsys):
+    assert rules.main(["show"]) == 0
+    out = capsys.readouterr().out
+    assert "delta_min" in out
+
+
+def test_validate_ok(tmp_path, capsys):
+    p = tmp_path / "crit.yaml"
+    p.write_text(VALID)
+    code = rules.main(["validate", str(p)])
+    assert code == 0
+    assert "Configuration OK" in capsys.readouterr().out
+
+
+def test_validate_bad(tmp_path, capsys):
+    p = tmp_path / "bad.yaml"
+    p.write_text("strike: {}")
+    code = rules.main(["validate", str(p)])
+    assert code == 1
+    assert "Invalid configuration" in capsys.readouterr().out

--- a/tomic/cli/app.py
+++ b/tomic/cli/app.py
@@ -8,6 +8,7 @@ from . import csv_quality_check
 from . import option_lookup
 from . import portfolio_scenario
 from . import generate_proposals
+from . import rules
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -53,6 +54,32 @@ def main(argv: list[str] | None = None) -> None:
         func=lambda a: generate_proposals.main(
             [p for p in [a.positions, a.export_dir] if p]
         )
+    )
+
+    sub_rules = sub.add_parser("rules", help="Inspect and reload rule config")
+    rules_sub = sub_rules.add_subparsers(dest="rules_cmd")
+
+    show = rules_sub.add_parser("show", help="Toon huidige configuratie")
+    show.add_argument("path", nargs="?", help="Pad naar criteria.yaml")
+    show.set_defaults(
+        func=lambda a: rules.main(["show"] + ([a.path] if a.path else []))
+    )
+
+    validate = rules_sub.add_parser("validate", help="Valideer configuratie")
+    validate.add_argument("path", nargs="?", help="Pad naar criteria.yaml")
+    validate.add_argument("--reload", action="store_true", help="Herlaad na validatie")
+    validate.set_defaults(
+        func=lambda a: rules.main(
+            ["validate"]
+            + ([a.path] if a.path else [])
+            + (["--reload"] if a.reload else [])
+        )
+    )
+
+    reload_cfg = rules_sub.add_parser("reload", help="Herlaad configuratie")
+    reload_cfg.add_argument("path", nargs="?", help="Pad naar criteria.yaml")
+    reload_cfg.set_defaults(
+        func=lambda a: rules.main(["reload"] + ([a.path] if a.path else []))
     )
 
     args = parser.parse_args(argv)

--- a/tomic/cli/rules.py
+++ b/tomic/cli/rules.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Utilities for validating and inspecting rule configuration.
+
+The commands defined here provide a safe way for non-developers to
+inspect and validate the :mod:`tomic.criteria` configuration.  They can
+optionally trigger a reload so a running service picks up the new
+configuration without a restart.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from .. import criteria
+from .. import config
+
+
+def _load(path: str | None = None) -> criteria.RulesConfig:
+    """Load rules from ``path`` re-reading the file every time."""
+    criteria.load_rules.cache_clear()
+    return criteria.load_rules(path)
+
+
+def _show(path: str | None) -> int:
+    """Display the current rules configuration."""
+    cfg = _load(path)
+    print(json.dumps(cfg.model_dump(), indent=2, sort_keys=True))
+    return 0
+
+
+def _validate(path: str | None, reload: bool = False) -> int:
+    """Validate configuration file and optionally reload services."""
+    cfg_path = Path(path) if path else Path(criteria.__file__).resolve().parent.parent / "criteria.yaml"
+    if not cfg_path.exists():
+        print(f"Configuration file not found: {cfg_path}")
+        return 1
+    try:
+        cfg = _load(str(cfg_path))
+    except ValidationError as exc:  # pragma: no cover - exercised in tests
+        print("Invalid configuration:\n" + str(exc))
+        return 1
+    print("Configuration OK")
+    if reload:
+        # Update global state so long running processes pick up changes
+        criteria.RULES = cfg
+        config.reload()
+        print("Reloaded running services")
+    return 0
+
+
+def _reload(path: str | None) -> int:
+    """Reload configuration unconditionally."""
+    cfg = _load(path)
+    criteria.RULES = cfg
+    config.reload()
+    print("Reloaded running services")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Manage rules configuration")
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_show = sub.add_parser("show", help="Display merged configuration")
+    p_show.add_argument("path", nargs="?", help="Path to criteria.yaml")
+    p_show.set_defaults(func=lambda a: _show(a.path))
+
+    p_val = sub.add_parser("validate", help="Validate configuration file")
+    p_val.add_argument("path", nargs="?", help="Path to criteria.yaml")
+    p_val.add_argument("--reload", action="store_true", help="Reload after validation")
+    p_val.set_defaults(func=lambda a: _validate(a.path, reload=a.reload))
+
+    p_rel = sub.add_parser("reload", help="Reload configuration")
+    p_rel.add_argument("path", nargs="?", help="Path to criteria.yaml")
+    p_rel.set_defaults(func=lambda a: _reload(a.path))
+
+    args = parser.parse_args(argv)
+    if hasattr(args, "func"):
+        return args.func(args)
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `tomic rules` CLI to show, validate and reload rules configuration
- document how to update rule criteria safely
- cover rule management CLI with tests

## Testing
- `pytest tests/cli/test_rules_cli.py -q`
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_b_689f033e3988832ea92524c62162615a