### PR TITLE
feat: add strategy criteria menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,28 @@ pytest tests/
 Om de volledige Polygon API-sleutel te loggen, zet je de omgevingsvariabele `TOMIC_SHOW_POLYGON_KEY=1` voordat je scripts start. De sleutel wordt dan niet gemaskeerd.
 
 📐 Rules configuratie beheren
-Met de ingebouwde CLI kun je de regels in `criteria.yaml` veilig aanpassen:
+Met de ingebouwde CLI kun je de regels in `criteria.yaml` veilig aanpassen. Via het configuratiemenu
+van het control panel is hiervoor het submenu **Strategie & Criteria** toegevoegd:
+
+```
+=== Strategie & Criteria ===
+1. Optie-strategie parameters
+2. Criteria beheren
+3. Terug
+```
+
+Kies **Criteria beheren** om de regels te bekijken, valideren of te herladen:
+
+```
+=== Criteria beheren ===
+1. Toon criteria
+2. Valideer criteria.yaml
+3. Valideer & reload
+4. Reload zonder validatie
+5. Terug
+```
+
+Vanuit het menu kun je tevens de regels valideren en desgewenst services herladen.
 
 ```bash
 # Toon de actuele configuratie

--- a/docs/rules_cli.md
+++ b/docs/rules_cli.md
@@ -2,6 +2,33 @@
 
 Deze CLI helpt bij het veilig aanpassen van `criteria.yaml`.
 
+## Strategie & Criteria submenu
+
+In het control panel vind je onder *Configuratie → Strategie & Criteria* een handig
+submenustructuur om zowel optie-strategie parameters als de regels in `criteria.yaml`
+te beheren:
+
+```
+=== Strategie & Criteria ===
+1. Optie-strategie parameters
+2. Criteria beheren
+3. Terug
+```
+
+Het onderdeel **Criteria beheren** toont de volgende opties:
+
+```
+=== Criteria beheren ===
+1. Toon criteria
+2. Valideer criteria.yaml
+3. Valideer & reload
+4. Reload zonder validatie
+5. Terug
+```
+
+Hier kun je optioneel een pad naar een alternatieve `criteria.yaml` invoeren voordat je
+valideert of herlaadt.
+
 ## Configuratie tonen
 
 ```

--- a/tests/cli/test_controlpanel_rules_menu.py
+++ b/tests/cli/test_controlpanel_rules_menu.py
@@ -1,0 +1,107 @@
+import importlib
+import types
+
+
+def _extract(code_obj, name):
+    for const in code_obj.co_consts:
+        if isinstance(const, types.CodeType) and const.co_name == name:
+            return const
+    return None
+
+
+def _cell(value):
+    return (lambda: value).__closure__[0]
+
+
+def test_strategy_criteria_menu_contains_items(monkeypatch):
+    mod = importlib.import_module("tomic.cli.controlpanel")
+    strat_code = _extract(mod.run_settings_menu.__code__, "run_strategy_criteria_menu")
+    assert strat_code is not None
+
+    calls = []
+    def fake_option():
+        calls.append("option")
+    def fake_rules():
+        calls.append("rules")
+
+    func = types.FunctionType(
+        strat_code,
+        mod.run_settings_menu.__globals__,
+        None,
+        None,
+        (
+            _cell(fake_option),
+            _cell(fake_rules),
+        ),
+    )
+
+    menu_holder = {}
+    class FakeMenu:
+        def __init__(self, title, exit_text="Terug"):
+            menu_holder["title"] = title
+            self.items = []
+            menu_holder["items"] = self.items
+        def add(self, desc, handler):
+            self.items.append((desc, handler))
+        def run(self):
+            pass
+    monkeypatch.setattr(mod, "Menu", FakeMenu)
+
+    func()
+
+    assert "Strategie & Criteria" in menu_holder["title"]
+    descriptions = [d for d, _ in menu_holder["items"]]
+    assert "Optie-strategie parameters" in descriptions
+    assert "Criteria beheren" in descriptions
+
+    for _, handler in menu_holder["items"]:
+        handler()
+    assert calls == ["option", "rules"]
+
+
+def test_rules_menu_executes_actions(monkeypatch):
+    mod = importlib.import_module("tomic.cli.controlpanel")
+    rules_code = _extract(mod.run_settings_menu.__code__, "run_rules_menu")
+    assert rules_code is not None
+
+    func = types.FunctionType(
+        rules_code,
+        mod.run_settings_menu.__globals__,
+        None,
+        None,
+        (),
+    )
+
+    actions = []
+    monkeypatch.setattr(mod, "run_module", lambda *a: actions.append(a))
+    monkeypatch.setattr(mod, "prompt", lambda *a, **k: "/tmp/crit.yaml")
+
+    menu_holder = {}
+    class FakeMenu:
+        def __init__(self, title, exit_text="Terug"):
+            menu_holder["title"] = title
+            self.items = []
+            menu_holder["items"] = self.items
+        def add(self, desc, handler):
+            self.items.append((desc, handler))
+        def run(self):
+            for _, h in self.items:
+                h()
+    monkeypatch.setattr(mod, "Menu", FakeMenu)
+
+    func()
+
+    assert "Criteria beheren" in menu_holder["title"]
+    descriptions = [d for d, _ in menu_holder["items"]]
+    assert descriptions == [
+        "Toon criteria",
+        "Valideer criteria.yaml",
+        "Valideer & reload",
+        "Reload zonder validatie",
+    ]
+    assert actions == [
+        ("tomic.cli.rules", "show"),
+        ("tomic.cli.rules", "validate", "/tmp/crit.yaml"),
+        ("tomic.cli.rules", "validate", "/tmp/crit.yaml", "--reload"),
+        ("tomic.cli.rules", "reload"),
+    ]

--- a/tomic/cli/controlpanel.py
+++ b/tomic/cli/controlpanel.py
@@ -1836,12 +1836,41 @@ def run_settings_menu() -> None:
         sub.add("Markt dicht – reqHistoricalData", run_closed_menu)
         sub.run()
 
+    def run_rules_menu() -> None:
+        path = prompt("Pad naar criteria.yaml (optioneel): ")
+        sub = Menu("\U0001F4DC Criteria beheren")
+
+        sub.add("Toon criteria", lambda: run_module("tomic.cli.rules", "show"))
+
+        def _validate() -> None:
+            if path:
+                run_module("tomic.cli.rules", "validate", path)
+            else:
+                run_module("tomic.cli.rules", "validate")
+
+        def _validate_reload() -> None:
+            if path:
+                run_module("tomic.cli.rules", "validate", path, "--reload")
+            else:
+                run_module("tomic.cli.rules", "validate", "--reload")
+
+        sub.add("Valideer criteria.yaml", _validate)
+        sub.add("Valideer & reload", _validate_reload)
+        sub.add("Reload zonder validatie", lambda: run_module("tomic.cli.rules", "reload"))
+        sub.run()
+
+    def run_strategy_criteria_menu() -> None:
+        sub = Menu("\U0001F3AF Strategie & Criteria")
+        sub.add("Optie-strategie parameters", run_option_menu)
+        sub.add("Criteria beheren", run_rules_menu)
+        sub.run()
+
     menu = Menu("\u2699\ufe0f INSTELLINGEN & CONFIGURATIE")
     menu.add("Portfolio & Analyse", run_general_menu)
     menu.add("Verbinding & API", run_connection_menu)
     menu.add("Netwerk & Snelheid", run_network_menu)
     menu.add("Bestandslocaties", run_paths_menu)
-    menu.add("Optie-strategie parameters", run_option_menu)
+    menu.add("Strategie & Criteria", run_strategy_criteria_menu)
     menu.add("Logging & Gedrag", run_logging_menu)
     menu.add("Toon volledige configuratie", show_config)
     menu.run()


### PR DESCRIPTION
## Summary
- add Strategy & Criteria submenu combining option parameters and criteria management
- document new menu with usage examples
- cover rules menu actions via tests

## Testing
- `pytest tests/cli/test_controlpanel_rules_menu.py -q`
- `pytest tests/cli/test_controlpanel_proposals.py::test_show_market_info -q`


------
https://chatgpt.com/codex/tasks/task_b_689f1f75f5b8832e9206933fef009535