### PR TITLE
Fix IV rank and percentile scaling

### DIFF
--- a/tomic/cli/compute_volstats_polygon.py
+++ b/tomic/cli/compute_volstats_polygon.py
@@ -247,6 +247,10 @@ def main(argv: List[str] | None = None) -> None:
         scaled_iv = iv * 100 if iv is not None else None
         rank = iv_rank(scaled_iv or 0.0, hv_series) if scaled_iv is not None else None
         pct = iv_percentile(scaled_iv or 0.0, hv_series) if scaled_iv is not None else None
+        if isinstance(rank, (int, float)) and rank > 1:
+            rank /= 100
+        if isinstance(pct, (int, float)) and pct > 1:
+            pct /= 100
 
         summary_record = {
             "date": date_str,

--- a/tomic/cli/controlpanel.py
+++ b/tomic/cli/controlpanel.py
@@ -550,6 +550,12 @@ def run_portfolio_menu() -> None:
                 if upcoming:
                     next_earn = min(upcoming).strftime("%Y-%m-%d")
 
+            rank = summary.get("iv_rank (HV)")
+            pct = summary.get("iv_percentile (HV)")
+            if isinstance(rank, (int, float)) and rank > 1:
+                rank /= 100
+            if isinstance(pct, (int, float)) and pct > 1:
+                pct /= 100
             rows.append(
                 [
                     symbol,
@@ -559,8 +565,8 @@ def run_portfolio_menu() -> None:
                     hv.get("hv30"),
                     hv.get("hv90"),
                     hv.get("hv252"),
-                    summary.get("iv_rank (HV)"),
-                    summary.get("iv_percentile (HV)"),
+                    rank,
+                    pct,
                     summary.get("term_m1_m2"),
                     summary.get("term_m1_m3"),
                     summary.get("skew"),
@@ -573,8 +579,8 @@ def run_portfolio_menu() -> None:
         def fmt4(val: float | None) -> str:
             return f"{val:.4f}" if val is not None else ""
 
-        def fmt0(val: float | None) -> str:
-            return f"{val * 100:.0f}" if val is not None else ""
+        def fmt2(val: float | None) -> str:
+            return f"{val:.2f}" if val is not None else ""
 
         formatted_rows = [
             [
@@ -585,8 +591,8 @@ def run_portfolio_menu() -> None:
                 fmt4(r[4]),
                 fmt4(r[5]),
                 fmt4(r[6]),
-                fmt0(r[7]),
-                fmt0(r[8]),
+                fmt2(r[7]),
+                fmt2(r[8]),
                 r[9],
                 r[10],
                 r[11],

--- a/tomic/cli/earnings_info.py
+++ b/tomic/cli/earnings_info.py
@@ -154,6 +154,8 @@ def main(argv: List[str] | None = None) -> None:
             continue
         iv_today_val = iv_today_rec.get("atm_iv")
         iv_rank_val = iv_today_rec.get("iv_rank (HV)")
+        if isinstance(iv_rank_val, (int, float)) and iv_rank_val > 1:
+            iv_rank_val /= 100
         hv_delta = historical_hv_delta(sym, dte, earnings_data, hv_data)
         proj_iv = None
         if hv_delta is not None and iv_today_val is not None:

--- a/tomic/providers/polygon_iv.py
+++ b/tomic/providers/polygon_iv.py
@@ -862,6 +862,10 @@ def fetch_polygon_iv30d(symbol: str) -> Dict[str, float | None] | None:
         scaled_iv = atm_iv * 100
         iv_rank = _iv_rank(scaled_iv, hv_series)
         iv_percentile = _iv_percentile(scaled_iv, hv_series)
+        if isinstance(iv_rank, (int, float)) and iv_rank > 1:
+            iv_rank /= 100
+        if isinstance(iv_percentile, (int, float)) and iv_percentile > 1:
+            iv_percentile /= 100
     else:
         logger.debug("Cannot compute IV rank without ATM IV")
 


### PR DESCRIPTION
## Summary
- Normalize Polygon IV rank and percentile metrics to decimals between 0 and 1
- Display IV rank/percentile in control panel as 0-1 with two decimals
- Ensure earnings and volatility stat scripts handle scaled values consistently

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a07793ccf8832e8847aaf803eaf04a