### PR TITLE
feat: show VIX in market info output

### DIFF
--- a/tests/cli/test_controlpanel_proposals.py
+++ b/tests/cli/test_controlpanel_proposals.py
@@ -73,6 +73,12 @@ def test_show_market_info(monkeypatch, tmp_path):
         ),
     )
 
+    monkeypatch.setattr(
+        mod,
+        "fetch_volatility_metrics",
+        lambda *a, **k: {"vix": 19.5},
+    )
+
     prints = []
     monkeypatch.setattr(builtins, "print", lambda *a, **k: prints.append(" ".join(str(x) for x in a)))
 
@@ -82,6 +88,7 @@ def test_show_market_info(monkeypatch, tmp_path):
 
     assert any("2030-01-01" in line for line in prints)
     assert any("short_put_spread" in line for line in prints)
+    assert any("VIX" in line for line in prints)
 
 
 def test_process_chain_refreshes_spot_price(monkeypatch, tmp_path):

--- a/tomic/cli/controlpanel.py
+++ b/tomic/cli/controlpanel.py
@@ -57,6 +57,7 @@ from tomic.logutils import setup_logging, logger
 from tomic.analysis.greeks import compute_portfolio_greeks
 from tomic.journal.utils import load_json, save_json
 from tomic.utils import today
+from tomic.analysis.volatility_fetcher import fetch_volatility_metrics
 from tomic.cli.volatility_recommender import recommend_strategy, recommend_strategies
 from tomic.api.market_export import load_exported_chain
 from tomic.cli import services
@@ -509,6 +510,15 @@ def run_portfolio_menu() -> None:
 
         symbols = [s.upper() for s in cfg.get("DEFAULT_SYMBOLS", [])]
         rows: list[list] = []
+
+        vix_value = None
+        try:
+            metrics = fetch_volatility_metrics(symbols[0] if symbols else "SPY")
+            vix_value = metrics.get("vix")
+        except Exception:
+            vix_value = None
+        if isinstance(vix_value, (int, float)):
+            print(f"VIX {vix_value:.2f}")
 
         for symbol in symbols:
             try:


### PR DESCRIPTION
## Summary
- show current VIX above market information table
- test market info shows VIX value

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a0b9da0fa4832e98087260be5c1b10