### PR TITLE
Track rejection reasons from strategy metrics

### DIFF
--- a/tests/analysis/test_calendar_candidates.py
+++ b/tests/analysis/test_calendar_candidates.py
@@ -18,7 +18,7 @@ def test_calendar_candidates_with_valid_pair(monkeypatch):
             }
         }
     }
-    props = calendar.generate("AAA", chain, cfg, 100.0, 1.0)
+    props, _ = calendar.generate("AAA", chain, cfg, 100.0, 1.0)
     assert isinstance(props, list)
 
 
@@ -40,5 +40,5 @@ def test_calendar_candidates_no_pairs(monkeypatch):
             }
         }
     }
-    props = calendar.generate("AAA", chain, cfg, 100.0, 1.0)
+    props, _ = calendar.generate("AAA", chain, cfg, 100.0, 1.0)
     assert not props

--- a/tests/analysis/test_calendar_helper.py
+++ b/tests/analysis/test_calendar_helper.py
@@ -32,7 +32,7 @@ def test_calendar_generates_from_valid_pairs(monkeypatch):
             }
         }
     }
-    props = calendar.generate("AAA", chain, cfg, 100.0, 1.0)
+    props, _ = calendar.generate("AAA", chain, cfg, 100.0, 1.0)
     assert isinstance(props, list)
     if props:
         assert props[0].legs[0]["strike"] == 100.0
@@ -59,5 +59,5 @@ def test_calendar_logs_skip_on_missing_mid(monkeypatch):
     monkeypatch.setattr(
         sc.logger, "info", lambda msg, *a, **k: infos.append(msg.format(*a))
     )
-    props = calendar.generate("AAA", chain, cfg, 100.0, 1.0)
+    props, _ = calendar.generate("AAA", chain, cfg, 100.0, 1.0)
     assert not props

--- a/tests/analysis/test_strategy_candidates_new.py
+++ b/tests/analysis/test_strategy_candidates_new.py
@@ -68,7 +68,7 @@ def test_generate_strategy_candidates_with_strings():
             }
         }
     }
-    props = iron_condor.generate("AAA", chain, cfg, 100.0, 1.0)
+    props, _ = iron_condor.generate("AAA", chain, cfg, 100.0, 1.0)
     assert isinstance(props, list)
     if props:
         for leg in props[0].legs:
@@ -98,8 +98,9 @@ def test_generate_strategy_candidates_missing_metrics_reason():
             }
         }
     }
-    props = iron_condor.generate("AAA", chain, cfg, 100.0, 1.0)
+    props, reasons = iron_condor.generate("AAA", chain, cfg, 100.0, 1.0)
     assert not props
+    assert reasons
 
 
 def test_parity_mid_used_for_missing_bidask(monkeypatch):
@@ -167,7 +168,7 @@ def test_parity_mid_used_for_missing_bidask(monkeypatch):
             }
         }
     }
-    props = iron_condor.generate("AAA", chain, cfg, 100.0, 1.0)
+    props, _ = iron_condor.generate("AAA", chain, cfg, 100.0, 1.0)
     assert props
     sc_leg = next(
         (

--- a/tests/analysis/test_strategy_modules.py
+++ b/tests/analysis/test_strategy_modules.py
@@ -43,5 +43,5 @@ chain = [
 @pytest.mark.parametrize("name,cfg", strategies)
 def test_strategy_modules_smoke(name, cfg):
     mod = importlib.import_module(f"tomic.strategies.{name.value}")
-    props = mod.generate("AAA", chain, cfg, 100.0, 1.0)
+    props, _ = mod.generate("AAA", chain, cfg, 100.0, 1.0)
     assert isinstance(props, list)

--- a/tomic/strategies/atm_iron_butterfly.py
+++ b/tomic/strategies/atm_iron_butterfly.py
@@ -18,7 +18,13 @@ from ..strategy_candidates import (
 )
 
 
-def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, Any], spot: float, atr: float) -> List[StrategyProposal]:
+def generate(
+    symbol: str,
+    option_chain: List[Dict[str, Any]],
+    config: Dict[str, Any],
+    spot: float,
+    atr: float,
+) -> tuple[List[StrategyProposal], list[str]]:
     strat_cfg = config.get("strategies", {}).get("atm_iron_butterfly", {})
     rules = strat_cfg.get("strike_to_strategy_config", {})
     use_atr = bool(rules.get("use_ATR"))
@@ -26,7 +32,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
         raise ValueError("spot price is required")
     expiries = sorted({str(o.get("expiry")) for o in option_chain})
     if not expiries:
-        return []
+        return [], []
     expiry = expiries[0]
     strike_map = _build_strike_map(option_chain)
     if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):
@@ -37,6 +43,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             df_chain = fill_missing_mid_with_parity(df_chain, spot=spot)
             option_chain = df_chain.to_dict(orient="records")
     proposals: List[StrategyProposal] = []
+    rejected_reasons: list[str] = []
     min_rr = float(strat_cfg.get("min_risk_reward", 0.0))
 
     def make_leg(opt: Dict[str, Any], position: int) -> Dict[str, Any] | None:
@@ -150,10 +157,12 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             ]
             if any(l is None for l in legs):
                 continue
-            metrics, _ = _metrics(StrategyName.ATM_IRON_BUTTERFLY, legs, spot)
+            metrics, reasons = _metrics(StrategyName.ATM_IRON_BUTTERFLY, legs, spot)
             if metrics and passes_risk(metrics):
                 proposals.append(StrategyProposal(legs=legs, **metrics))
+            elif reasons:
+                rejected_reasons.extend(reasons)
             if len(proposals) >= 5:
                 break
     proposals.sort(key=lambda p: p.score or 0, reverse=True)
-    return proposals[:5]
+    return proposals[:5], sorted(set(rejected_reasons))

--- a/tomic/strategies/backspread_put.py
+++ b/tomic/strategies/backspread_put.py
@@ -20,7 +20,13 @@ from ..strategy_candidates import (
 )
 
 
-def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, Any], spot: float, atr: float) -> List[StrategyProposal]:
+def generate(
+    symbol: str,
+    option_chain: List[Dict[str, Any]],
+    config: Dict[str, Any],
+    spot: float,
+    atr: float,
+) -> tuple[List[StrategyProposal], list[str]]:
     strat_cfg = config.get("strategies", {}).get("backspread_put", {})
     rules = strat_cfg.get("strike_to_strategy_config", {})
     use_atr = bool(rules.get("use_ATR"))
@@ -28,7 +34,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
         raise ValueError("spot price is required")
     expiries = sorted({str(o.get("expiry")) for o in option_chain})
     if not expiries:
-        return []
+        return [], []
     strike_map = _build_strike_map(option_chain)
     if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):
         df_chain = pd.DataFrame(option_chain)
@@ -38,6 +44,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             df_chain = fill_missing_mid_with_parity(df_chain, spot=spot)
             option_chain = df_chain.to_dict(orient="records")
     proposals: List[StrategyProposal] = []
+    rejected_reasons: list[str] = []
     min_rr = float(strat_cfg.get("min_risk_reward", 0.0))
 
     def make_leg(opt: Dict[str, Any], position: int) -> Dict[str, Any] | None:
@@ -152,11 +159,13 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
                 legs = [make_leg(short_opt, -1), make_leg(long_opt, 2)]
                 if any(l is None for l in legs):
                     continue
-                metrics, _ = _metrics(StrategyName.BACKSPREAD_PUT, legs, spot)
+                metrics, reasons = _metrics(StrategyName.BACKSPREAD_PUT, legs, spot)
                 if metrics and passes_risk(metrics):
                     if _validate_ratio("backspread_put", legs, metrics.get("credit", 0.0)):
                         proposals.append(StrategyProposal(legs=legs, **metrics))
+                elif reasons:
+                    rejected_reasons.extend(reasons)
                 if len(proposals) >= 5:
                     break
     proposals.sort(key=lambda p: p.score or 0, reverse=True)
-    return proposals[:5]
+    return proposals[:5], sorted(set(rejected_reasons))

--- a/tomic/strategies/iron_condor.py
+++ b/tomic/strategies/iron_condor.py
@@ -20,7 +20,13 @@ from ..strategy_candidates import (
 )
 
 
-def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, Any], spot: float, atr: float) -> List[StrategyProposal]:
+def generate(
+    symbol: str,
+    option_chain: List[Dict[str, Any]],
+    config: Dict[str, Any],
+    spot: float,
+    atr: float,
+) -> tuple[List[StrategyProposal], list[str]]:
     strat_cfg = config.get("strategies", {}).get("iron_condor", {})
     rules = strat_cfg.get("strike_to_strategy_config", {})
     use_atr = bool(rules.get("use_ATR"))
@@ -28,7 +34,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
         raise ValueError("spot price is required")
     expiries = sorted({str(o.get("expiry")) for o in option_chain})
     if not expiries:
-        return []
+        return [], []
     expiry = expiries[0]
     strike_map = _build_strike_map(option_chain)
     if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):
@@ -39,6 +45,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             df_chain = fill_missing_mid_with_parity(df_chain, spot=spot)
             option_chain = df_chain.to_dict(orient="records")
     proposals: List[StrategyProposal] = []
+    rejected_reasons: list[str] = []
     min_rr = float(strat_cfg.get("min_risk_reward", 0.0))
 
     def make_leg(opt: Dict[str, Any], position: int) -> Dict[str, Any] | None:
@@ -149,8 +156,10 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
         ]
         if any(l is None for l in legs):
             continue
-        metrics, _ = _metrics(StrategyName.IRON_CONDOR, legs, spot)
+        metrics, reasons = _metrics(StrategyName.IRON_CONDOR, legs, spot)
         if metrics and passes_risk(metrics):
             proposals.append(StrategyProposal(legs=legs, **metrics))
+        elif reasons:
+            rejected_reasons.extend(reasons)
     proposals.sort(key=lambda p: p.score or 0, reverse=True)
-    return proposals[:5]
+    return proposals[:5], sorted(set(rejected_reasons))

--- a/tomic/strategies/ratio_spread.py
+++ b/tomic/strategies/ratio_spread.py
@@ -19,7 +19,13 @@ from ..strategy_candidates import (
 )
 
 
-def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, Any], spot: float, atr: float) -> List[StrategyProposal]:
+def generate(
+    symbol: str,
+    option_chain: List[Dict[str, Any]],
+    config: Dict[str, Any],
+    spot: float,
+    atr: float,
+) -> tuple[List[StrategyProposal], list[str]]:
     strat_cfg = config.get("strategies", {}).get("ratio_spread", {})
     rules = strat_cfg.get("strike_to_strategy_config", {})
     use_atr = bool(rules.get("use_ATR"))
@@ -27,7 +33,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
         raise ValueError("spot price is required")
     expiries = sorted({str(o.get("expiry")) for o in option_chain})
     if not expiries:
-        return []
+        return [], []
     expiry = expiries[0]
     strike_map = _build_strike_map(option_chain)
     if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):
@@ -38,6 +44,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             df_chain = fill_missing_mid_with_parity(df_chain, spot=spot)
             option_chain = df_chain.to_dict(orient="records")
     proposals: List[StrategyProposal] = []
+    rejected_reasons: list[str] = []
     min_rr = float(strat_cfg.get("min_risk_reward", 0.0))
 
     def make_leg(opt: Dict[str, Any], position: int) -> Dict[str, Any] | None:
@@ -170,11 +177,13 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             legs = [make_leg(short_opt, -1), make_leg(long_opt, 2)]
             if any(l is None for l in legs):
                 continue
-            metrics, _ = _metrics(StrategyName.RATIO_SPREAD, legs, spot)
+            metrics, reasons = _metrics(StrategyName.RATIO_SPREAD, legs, spot)
             if metrics and passes_risk(metrics):
                 if _validate_ratio("ratio_spread", legs, metrics.get("credit", 0.0)):
                     proposals.append(StrategyProposal(legs=legs, **metrics))
+            elif reasons:
+                rejected_reasons.extend(reasons)
             if len(proposals) >= 5:
                 break
     proposals.sort(key=lambda p: p.score or 0, reverse=True)
-    return proposals[:5]
+    return proposals[:5], sorted(set(rejected_reasons))

--- a/tomic/strategies/short_call_spread.py
+++ b/tomic/strategies/short_call_spread.py
@@ -18,7 +18,13 @@ from ..strategy_candidates import (
 )
 
 
-def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, Any], spot: float, atr: float) -> List[StrategyProposal]:
+def generate(
+    symbol: str,
+    option_chain: List[Dict[str, Any]],
+    config: Dict[str, Any],
+    spot: float,
+    atr: float,
+) -> tuple[List[StrategyProposal], list[str]]:
     strat_cfg = config.get("strategies", {}).get("short_call_spread", {})
     rules = strat_cfg.get("strike_to_strategy_config", {})
     use_atr = bool(rules.get("use_ATR"))
@@ -26,7 +32,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
         raise ValueError("spot price is required")
     expiries = sorted({str(o.get("expiry")) for o in option_chain})
     if not expiries:
-        return []
+        return [], []
     expiry = expiries[0]
     strike_map = _build_strike_map(option_chain)
     if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):
@@ -37,6 +43,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             df_chain = fill_missing_mid_with_parity(df_chain, spot=spot)
             option_chain = df_chain.to_dict(orient="records")
     proposals: List[StrategyProposal] = []
+    rejected_reasons: list[str] = []
     min_rr = float(strat_cfg.get("min_risk_reward", 0.0))
 
     def make_leg(opt: Dict[str, Any], position: int) -> Dict[str, Any] | None:
@@ -148,10 +155,12 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             legs = [make_leg(short_opt, -1), make_leg(long_opt, 1)]
             if any(l is None for l in legs):
                 continue
-            metrics, _ = _metrics(StrategyName.SHORT_CALL_SPREAD, legs, spot)
+            metrics, reasons = _metrics(StrategyName.SHORT_CALL_SPREAD, legs, spot)
             if metrics and passes_risk(metrics):
                 proposals.append(StrategyProposal(legs=legs, **metrics))
+            elif reasons:
+                rejected_reasons.extend(reasons)
             if len(proposals) >= 5:
                 break
     proposals.sort(key=lambda p: p.score or 0, reverse=True)
-    return proposals[:5]
+    return proposals[:5], sorted(set(rejected_reasons))

--- a/tomic/strategies/short_put_spread.py
+++ b/tomic/strategies/short_put_spread.py
@@ -18,7 +18,13 @@ from ..strategy_candidates import (
 )
 
 
-def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, Any], spot: float, atr: float) -> List[StrategyProposal]:
+def generate(
+    symbol: str,
+    option_chain: List[Dict[str, Any]],
+    config: Dict[str, Any],
+    spot: float,
+    atr: float,
+) -> tuple[List[StrategyProposal], list[str]]:
     strat_cfg = config.get("strategies", {}).get("short_put_spread", {})
     rules = strat_cfg.get("strike_to_strategy_config", {})
     use_atr = bool(rules.get("use_ATR"))
@@ -26,7 +32,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
         raise ValueError("spot price is required")
     expiries = sorted({str(o.get("expiry")) for o in option_chain})
     if not expiries:
-        return []
+        return [], []
     expiry = expiries[0]
     strike_map = _build_strike_map(option_chain)
     if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):
@@ -37,6 +43,7 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             df_chain = fill_missing_mid_with_parity(df_chain, spot=spot)
             option_chain = df_chain.to_dict(orient="records")
     proposals: List[StrategyProposal] = []
+    rejected_reasons: list[str] = []
     min_rr = float(strat_cfg.get("min_risk_reward", 0.0))
 
     def make_leg(opt: Dict[str, Any], position: int) -> Dict[str, Any] | None:
@@ -148,10 +155,12 @@ def generate(symbol: str, option_chain: List[Dict[str, Any]], config: Dict[str, 
             legs = [make_leg(short_opt, -1), make_leg(long_opt, 1)]
             if any(l is None for l in legs):
                 continue
-            metrics, _ = _metrics(StrategyName.SHORT_PUT_SPREAD, legs, spot)
+            metrics, reasons = _metrics(StrategyName.SHORT_PUT_SPREAD, legs, spot)
             if metrics and passes_risk(metrics):
                 proposals.append(StrategyProposal(legs=legs, **metrics))
+            elif reasons:
+                rejected_reasons.extend(reasons)
             if len(proposals) >= 5:
                 break
     proposals.sort(key=lambda p: p.score or 0, reverse=True)
-    return proposals[:5]
+    return proposals[:5], sorted(set(rejected_reasons))


### PR DESCRIPTION
## Summary
- Collect rejection reasons in strategy modules and return them alongside proposals
- Handle `(proposals, reasons)` tuples in `generate_strategy_candidates`
- Ensure control panel displays each rejection reason when no proposals are generated

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a0d66756a8832e831f154d5b6735d2