### PR TITLE
Store spot price in dedicated cache file

### DIFF
--- a/tests/cli/test_controlpanel_proposals.py
+++ b/tests/cli/test_controlpanel_proposals.py
@@ -4,7 +4,7 @@ import json
 import types
 from datetime import datetime, timedelta
 from pathlib import Path
-from tomic.journal.utils import save_json
+from tomic.journal.utils import save_json, load_json
 from tomic.strategy_candidates import StrategyProposal
 
 
@@ -236,6 +236,11 @@ def test_process_chain_refreshes_spot_price(monkeypatch, tmp_path):
     assert mod.SESSION_STATE.get("spot_price") == 202.0
     assert any("• r1" in line for line in prints)
     assert any("• r2" in line for line in prints)
+
+    spot_path = tmp_path / "AAA_spot.json"
+    assert spot_path.exists(), "spot cache should use _spot.json suffix"
+    assert not (tmp_path / "AAA.json").exists(), "historical data file must remain untouched"
+    assert load_json(spot_path).get("price") == 202.0
 
 
 def test_export_proposal_json_includes_earnings(monkeypatch, tmp_path):

--- a/tomic/cli/controlpanel.py
+++ b/tomic/cli/controlpanel.py
@@ -113,14 +113,15 @@ def refresh_spot_price(symbol: str) -> float | None:
     """Fetch and cache the current spot price for ``symbol``.
 
     Uses :class:`PolygonClient` to retrieve the delayed last trade price and
-    caches it under :data:`PRICE_HISTORY_DIR`. When existing data is newer
-    than roughly ten minutes the cached value is reused.
+    caches it under :data:`PRICE_HISTORY_DIR` as ``<SYMBOL>_spot.json``.
+    When existing data is newer than roughly ten minutes the cached value is
+    reused.
     """
 
     sym = symbol.upper()
     base = Path(cfg.get("PRICE_HISTORY_DIR", "tomic/data/spot_prices"))
     base.mkdir(parents=True, exist_ok=True)
-    spot_file = base / f"{sym}.json"
+    spot_file = base / f"{sym}_spot.json"
 
     meta = load_price_meta()
     now = datetime.now()


### PR DESCRIPTION
## Summary
- save spot prices to `<symbol>_spot.json` instead of overwriting historical data
- test `refresh_spot_price` creates separate cache file

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a0db400268832e927cfc63328f09f3