### PR TITLE
Separate metadata keys for spot, daily, and intraday prices

### DIFF
--- a/tests/cli/test_controlpanel_proposals.py
+++ b/tests/cli/test_controlpanel_proposals.py
@@ -236,6 +236,7 @@ def test_process_chain_refreshes_spot_price(monkeypatch, tmp_path):
     assert mod.SESSION_STATE.get("spot_price") == 202.0
     assert any("• r1" in line for line in prints)
     assert any("• r2" in line for line in prints)
+    assert "spot_AAA" in meta_store
 
     spot_path = tmp_path / "AAA_spot.json"
     assert spot_path.exists(), "spot cache should use _spot.json suffix"

--- a/tests/cli/test_fetch_intraday_polygon.py
+++ b/tests/cli/test_fetch_intraday_polygon.py
@@ -78,7 +78,7 @@ def test_intraday_overwrite(monkeypatch, tmp_path):
     assert len(data) == 2
     assert data[-1]["close"] == 10.0
     meta1 = json.loads(meta_file.read_text())
-    ts1 = meta1.get("ABC")
+    ts1 = meta1.get("intraday_ABC")
     assert ts1
 
     # second fetch should overwrite today's record
@@ -87,4 +87,4 @@ def test_intraday_overwrite(monkeypatch, tmp_path):
     assert len(data2) == 2
     assert data2[-1]["close"] == 11.0
     meta2 = json.loads(meta_file.read_text())
-    assert meta2.get("ABC") != ts1
+    assert meta2.get("intraday_ABC") != ts1

--- a/tests/cli/test_fetch_prices_polygon.py
+++ b/tests/cli/test_fetch_prices_polygon.py
@@ -50,6 +50,7 @@ def test_fetch_prices_polygon_main(monkeypatch):
     assert captured
     assert captured[0]["close"] == 1.23
     assert called and called[0] == ["ABC"]
+    assert "day_ABC" in meta_store
 
 
 def test_fetch_prices_polygon_no_data(monkeypatch):
@@ -80,6 +81,7 @@ def test_fetch_prices_polygon_no_data(monkeypatch):
 
     mod.main(["XYZ"])
     assert not captured
+    assert meta_store == {}
 
 
 def test_latest_trading_day_before_close(monkeypatch):
@@ -137,7 +139,7 @@ def test_incomplete_day_triggers_refetch(monkeypatch, tmp_path):
     (price_dir / "ABC.json").write_text(json.dumps([{"date": "2024-01-02", "close": 1.0}]))
 
     meta_file = tmp_path / "meta.json"
-    meta_file.write_text(json.dumps({"ABC": "2024-01-02T15:00:00-05:00"}))
+    meta_file.write_text(json.dumps({"day_ABC": "2024-01-02T15:00:00-05:00"}))
 
     cfg_lambda = lambda name, default=None: (
         str(price_dir)
@@ -197,3 +199,4 @@ def test_no_new_workday_skips_sleep(monkeypatch):
 
     mod.main(["AAA", "BBB"])
     assert sleep_calls == []
+    assert meta_store == {}

--- a/tomic/cli/controlpanel.py
+++ b/tomic/cli/controlpanel.py
@@ -125,7 +125,8 @@ def refresh_spot_price(symbol: str) -> float | None:
 
     meta = load_price_meta()
     now = datetime.now()
-    ts_str = meta.get(sym)
+    meta_key = f"spot_{sym}"
+    ts_str = meta.get(meta_key)
     if spot_file.exists() and ts_str:
         try:
             ts = datetime.fromisoformat(ts_str)
@@ -159,7 +160,7 @@ def refresh_spot_price(symbol: str) -> float | None:
         return None
 
     save_json({"price": float(price), "timestamp": now.isoformat()}, spot_file)
-    meta[sym] = now.isoformat()
+    meta[meta_key] = now.isoformat()
     save_price_meta(meta)
     return float(price)
 

--- a/tomic/cli/fetch_intraday_polygon.py
+++ b/tomic/cli/fetch_intraday_polygon.py
@@ -73,7 +73,9 @@ def main(argv: List[str] | None = None) -> None:
             _store_record(file, record)
             stored += 1
             meta = load_price_meta()
-            meta[sym] = datetime.now(ZoneInfo("America/New_York")).isoformat()
+            meta[f"intraday_{sym}"] = datetime.now(
+                ZoneInfo("America/New_York")
+            ).isoformat()
             save_price_meta(meta)
             sleep(0.1)
     finally:

--- a/tomic/cli/fetch_prices_polygon.py
+++ b/tomic/cli/fetch_prices_polygon.py
@@ -77,7 +77,7 @@ def _request_bars(client: PolygonClient, symbol: str) -> tuple[list[dict], bool]
     end_dt = latest_trading_day()
     _, last_date = _load_latest_close(symbol)
     meta = load_price_meta()
-    ts_str = meta.get(symbol)
+    ts_str = meta.get(f"day_{symbol}")
     if last_date and ts_str:
         try:
             tz = ZoneInfo("America/New_York")
@@ -235,7 +235,9 @@ def main(argv: List[str] | None = None) -> None:
                     stored += 1
                     sleep(10)
                 meta = load_price_meta()
-                meta[sym] = datetime.now(ZoneInfo("America/New_York")).isoformat()
+                meta[f"day_{sym}"] = datetime.now(
+                    ZoneInfo("America/New_York")
+                ).isoformat()
                 save_price_meta(meta)
             processed.append(sym)
             if requested:


### PR DESCRIPTION
## Summary
- use dedicated metadata keys for spot, daily, and intraday price fetches
- update price-fetch scripts to read/write their own metadata key
- adjust tests for new metadata structure

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a0ddea13c0832e861d87ad46c4d826