### PR TITLE
Add reason when strategy expiries are missing

### DIFF
--- a/tomic/strategies/atm_iron_butterfly.py
+++ b/tomic/strategies/atm_iron_butterfly.py
@@ -32,7 +32,7 @@ def generate(
         raise ValueError("spot price is required")
     expiries = sorted({str(o.get("expiry")) for o in option_chain})
     if not expiries:
-        return [], []
+        return [], ["geen expiraties beschikbaar"]
     expiry = expiries[0]
     strike_map = _build_strike_map(option_chain)
     if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):

--- a/tomic/strategies/backspread_put.py
+++ b/tomic/strategies/backspread_put.py
@@ -34,7 +34,7 @@ def generate(
         raise ValueError("spot price is required")
     expiries = sorted({str(o.get("expiry")) for o in option_chain})
     if not expiries:
-        return [], []
+        return [], ["geen expiraties beschikbaar"]
     strike_map = _build_strike_map(option_chain)
     if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):
         df_chain = pd.DataFrame(option_chain)

--- a/tomic/strategies/calendar.py
+++ b/tomic/strategies/calendar.py
@@ -31,7 +31,7 @@ def generate(
     use_atr = bool(rules.get("use_ATR"))
     expiries = sorted({str(o.get("expiry")) for o in option_chain})
     if not expiries:
-        return [], []
+        return [], ["geen expiraties beschikbaar"]
     if spot is None:
         raise ValueError("spot price is required")
     expiry = expiries[0]

--- a/tomic/strategies/iron_condor.py
+++ b/tomic/strategies/iron_condor.py
@@ -34,7 +34,7 @@ def generate(
         raise ValueError("spot price is required")
     expiries = sorted({str(o.get("expiry")) for o in option_chain})
     if not expiries:
-        return [], []
+        return [], ["geen expiraties beschikbaar"]
     expiry = expiries[0]
     strike_map = _build_strike_map(option_chain)
     if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):

--- a/tomic/strategies/naked_put.py
+++ b/tomic/strategies/naked_put.py
@@ -28,7 +28,7 @@ def generate(
         raise ValueError("spot price is required")
     expiries = sorted({str(o.get("expiry")) for o in option_chain})
     if not expiries:
-        return [], []
+        return [], ["geen expiraties beschikbaar"]
     expiry = expiries[0]
     strike_map = _build_strike_map(option_chain)
     if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):

--- a/tomic/strategies/ratio_spread.py
+++ b/tomic/strategies/ratio_spread.py
@@ -33,7 +33,7 @@ def generate(
         raise ValueError("spot price is required")
     expiries = sorted({str(o.get("expiry")) for o in option_chain})
     if not expiries:
-        return [], []
+        return [], ["geen expiraties beschikbaar"]
     expiry = expiries[0]
     strike_map = _build_strike_map(option_chain)
     if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):

--- a/tomic/strategies/short_call_spread.py
+++ b/tomic/strategies/short_call_spread.py
@@ -32,7 +32,7 @@ def generate(
         raise ValueError("spot price is required")
     expiries = sorted({str(o.get("expiry")) for o in option_chain})
     if not expiries:
-        return [], []
+        return [], ["geen expiraties beschikbaar"]
     expiry = expiries[0]
     strike_map = _build_strike_map(option_chain)
     if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):

--- a/tomic/strategies/short_put_spread.py
+++ b/tomic/strategies/short_put_spread.py
@@ -32,7 +32,7 @@ def generate(
         raise ValueError("spot price is required")
     expiries = sorted({str(o.get("expiry")) for o in option_chain})
     if not expiries:
-        return [], []
+        return [], ["geen expiraties beschikbaar"]
     expiry = expiries[0]
     strike_map = _build_strike_map(option_chain)
     if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):


### PR DESCRIPTION
## Summary
- Return clear reason when no expirations are available in strategy generators

## Testing
- `pytest` *(fails: command not found; unable to install pytest due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68a18e32d88c832ea9358d96c7d385f1