### PR TITLE
Add helper to persist default symbols

### DIFF
--- a/tomic/cli/controlpanel.py
+++ b/tomic/cli/controlpanel.py
@@ -53,6 +53,7 @@ from tomic.cli.common import Menu, prompt, prompt_yes_no
 from tomic.api.ib_connection import connect_ib
 
 from tomic import config as cfg
+from tomic.config import save_symbols
 from tomic.logutils import setup_logging, logger
 from tomic.analysis.greeks import compute_portfolio_greeks
 from tomic.journal.utils import load_json, save_json
@@ -1673,7 +1674,7 @@ def run_settings_menu() -> None:
         raw = prompt("Nieuw lijst (comma-sep): ")
         if raw:
             symbols = [s.strip().upper() for s in raw.split(",") if s.strip()]
-            cfg.update({"DEFAULT_SYMBOLS": symbols})
+            save_symbols(symbols)
 
     def change_rate() -> None:
         rate_str = prompt(f"Rente ({cfg.CONFIG.INTEREST_RATE}): ")

--- a/tomic/config.py
+++ b/tomic/config.py
@@ -265,6 +265,20 @@ def save_config(config: AppConfig, path: Path | None = None) -> None:
         yaml.safe_dump(_asdict(config), f)
 
 
+def save_symbols(symbols: List[str], path: Path | None = None) -> None:
+    """Persist default symbols to a YAML file and update CONFIG."""
+    if path is None:
+        path = _BASE_DIR / "config" / "symbols.yaml"
+    try:
+        import yaml  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("PyYAML required for YAML config") from exc
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.safe_dump([str(s) for s in symbols], f)
+    with LOCK:
+        CONFIG.DEFAULT_SYMBOLS = [str(s) for s in symbols]
+
+
 CONFIG = load_config()
 LOCK = threading.Lock()
 STRATEGY_SCENARIOS = _load_strategy_scenarios()


### PR DESCRIPTION
## Summary
- add `save_symbols` helper to persist default symbols to `config/symbols.yaml`
- use new helper in control panel instead of generic config update

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a1916e2f84832e9216ac5742cdd126