### PR TITLE
Ensure default symbols always present in meta files

### DIFF
--- a/tomic/cli/fetch_earnings_alpha.py
+++ b/tomic/cli/fetch_earnings_alpha.py
@@ -99,6 +99,11 @@ def main(argv: List[str] | None = None) -> None:
     if not isinstance(meta, dict):
         meta = {}
 
+    # Ensure newly added symbols are present in stored data
+    for sym in symbols:
+        data.setdefault(sym, [])
+        meta.setdefault(sym, "")
+
     def _last_seen(sym: str) -> datetime:
         ts = meta.get(sym)
         if isinstance(ts, str):

--- a/tomic/helpers/price_meta.py
+++ b/tomic/helpers/price_meta.py
@@ -9,11 +9,24 @@ from tomic.logutils import logger
 from tomic.journal.utils import load_json, save_json
 
 
+def ensure_all_symbols(meta: dict[str, str]) -> dict[str, str]:
+    """Ensure all configured symbols exist in ``meta``.
+
+    Missing symbols from :func:`cfg_get("DEFAULT_SYMBOLS")` are initialised
+    with an empty timestamp so that new tickers are tracked automatically.
+    """
+
+    for sym in [s.upper() for s in cfg_get("DEFAULT_SYMBOLS", [])]:
+        meta.setdefault(sym, "")
+    return meta
+
+
 def load_price_meta() -> dict[str, str]:
     """Return mapping of symbols to ISO timestamp strings."""
     path = Path(cfg_get("PRICE_META_FILE", "price_meta.json"))
     data = load_json(path)
-    return data if isinstance(data, dict) else {}
+    meta = data if isinstance(data, dict) else {}
+    return ensure_all_symbols(meta)
 
 
 def save_price_meta(meta: dict[str, str]) -> None:


### PR DESCRIPTION
## Summary
- ensure price metadata includes empty entries for all `DEFAULT_SYMBOLS`
- auto-populate earnings JSONs with missing default tickers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a1c91f5d04832e9498fa2ee912d9c6