### PR TITLE
Ensure generate_strategy_candidates always returns list

### DIFF
--- a/tests/analysis/test_strategy_dynamic_config.py
+++ b/tests/analysis/test_strategy_dynamic_config.py
@@ -49,7 +49,9 @@ def test_generate_candidates_uses_global_config(monkeypatch):
             [],
         ),
     )
-    proposals, reason = generate_strategy_candidates("AAA", "iron_condor", chain, 1.0, None, 100.0)
-    assert reason is None
+    proposals, reasons = generate_strategy_candidates(
+        "AAA", "iron_condor", chain, 1.0, None, 100.0
+    )
+    assert reasons == []
     assert isinstance(proposals, list)
     assert proposals

--- a/tomic/cli/controlpanel.py
+++ b/tomic/cli/controlpanel.py
@@ -1087,7 +1087,7 @@ def run_portfolio_menu() -> None:
                 else:
                     print("Spotprice: n/a")
 
-                proposals, reason = generate_strategy_candidates(
+                proposals, reasons = generate_strategy_candidates(
                     symbol,
                     strat,
                     selected,
@@ -1187,14 +1187,11 @@ def run_portfolio_menu() -> None:
                         break
                 else:
                     msg = "⚠️ Geen voorstellen gevonden"
-                    if reason is not None:
-                        if not reason:
-                            msg += "\n• geen detailreden ontvangen"
-                        elif isinstance(reason, list):
-                            for r in reason:
-                                msg += f"\n• {r}"
-                        else:
-                            msg += f"\n• {reason}"
+                    if not reasons:
+                        msg += "\n• geen detailreden ontvangen"
+                    else:
+                        for r in reasons:
+                            msg += f"\n• {r}"
                     print(msg)
         else:
             print("⚠️ Geen geschikte strikes gevonden.")

--- a/tomic/strategy_candidates.py
+++ b/tomic/strategy_candidates.py
@@ -578,7 +578,7 @@ def generate_strategy_candidates(
     spot: float | None = None,
     *,
     interactive_mode: bool = False,
-) -> tuple[List[StrategyProposal], list[str] | None]:
+) -> tuple[List[StrategyProposal], list[str]]:
     """Load strategy module and generate candidates."""
     if spot is None:
         raise ValueError("spot price is required")
@@ -594,7 +594,7 @@ def generate_strategy_candidates(
         proposals, reasons = result
     else:  # backward compatibility
         proposals, reasons = result, None
-    return proposals, (sorted(set(reasons)) if reasons else None)
+    return proposals, sorted(set(reasons)) if reasons is not None else []
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Update `generate_strategy_candidates` to always return a list of rejection reasons
- Adjust CLI and tests to handle reason lists consistently

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a1c5338a88832e8f65269e5f0c46a5