### PR TITLE
Expose rejection details from StrikeSelector and surface summary in control panel

### DIFF
--- a/tomic/cli/controlpanel.py
+++ b/tomic/cli/controlpanel.py
@@ -913,7 +913,9 @@ def run_portfolio_menu() -> None:
 
         selector = StrikeSelector(config=fc)
         debug_csv = Path(cfg.get("EXPORT_DIR", "exports")) / "PEP_debugfilter.csv"
-        selected = selector.select(filtered, debug_csv=debug_csv)
+        selected, reject_reasons, reject_by_filter = selector.select(
+            filtered, debug_csv=debug_csv, return_info=True
+        )
 
         evaluated: list[dict[str, object]] = []
         for opt in selected:
@@ -1195,6 +1197,12 @@ def run_portfolio_menu() -> None:
                     print(msg)
         else:
             print("⚠️ Geen geschikte strikes gevonden.")
+            if reject_by_filter:
+                print("Afwijzingen per filter:")
+                for flt, cnt in sorted(
+                    reject_by_filter.items(), key=lambda x: x[1], reverse=True
+                ):
+                    print(f"• {flt}: {cnt}")
             print("➤ Controleer of de juiste expiraties beschikbaar zijn in de chain.")
             print("➤ Of pas je selectiecriteria aan in strike_selection_rules.yaml.")
 

--- a/tomic/strike_selector.py
+++ b/tomic/strike_selector.py
@@ -167,8 +167,18 @@ class StrikeSelector:
         *,
         dte_range: Tuple[int, int] | None = None,
         debug_csv: str | os.PathLike[str] | None = None,
-    ) -> List[Dict[str, Any]]:
-        """Return ``options`` filtered by expiry and configured criteria."""
+        return_info: bool = False,
+    ) -> (
+        List[Dict[str, Any]]
+        | Tuple[List[Dict[str, Any]], Dict[str, int], Dict[str, int]]
+    ):
+        """Return ``options`` filtered by expiry and configured criteria.
+
+        When ``return_info`` is :data:`True`, a tuple of ``(selected,
+        reasons, by_filter)`` is returned where ``reasons`` contains counts of
+        individual rejection reasons and ``by_filter`` aggregates these counts
+        per filter category.
+        """
 
         logger.info(
             f"StrikeSelector start: {len(options)} options, dte_range={dte_range}, config={self.config}"
@@ -231,7 +241,8 @@ class StrikeSelector:
             logger.info(
                 f"[FILTER] Geen opties over na filtering — config: delta={self.config.delta_min}..{self.config.delta_max}, rom={self.config.min_rom}, dte={dte_range}, edge={self.config.min_edge}"
             )
-
+        if return_info:
+            return selected, reasons, by_filter
         return selected
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add optional `return_info` flag to `StrikeSelector.select` returning detailed rejection counts
- update controlpanel to use rejection info and display brief summary when no strikes remain

## Testing
- `pytest tests/analysis/test_strike_selector.py tests/helpers/test_strike_selector.py`


------
https://chatgpt.com/codex/tasks/task_b_68a20191a734832eb1a196ecd34e09de