### PR TITLE
docs: document filter stats option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ Krijg je geen voorstellen, dan toont TOMIC nu ook hoeveel combinaties zijn
 afgewezen door een ratioscheck of risicocriteria. Zo weet je direct waarom er
 geen strategie werd gevonden.
 
+Wil je exact zien welke regels kandidaten uitsloten? Start de analyse met
+`--show-filter-stats` of zet de omgevingsvariabele `EXPLAIN_FILTERS=true`.
+TOMIC meldt dan per filter hoeveel combinaties zijn afgevallen:
+
+```
+$ tomic analysis --show-filter-stats
+min_rom            : 12
+delta_range        : 8
+market_data.volume : 3
+```
+
+Blijkt een regel te streng, pas dan de waarden in `criteria.yaml` of
+`tomic/strike_selection_rules.yaml` aan en valideer ze via `tomic rules
+validate <pad/naar/criteria.yaml> --reload`.
+
 Bij onvoldoende volume of open interest toont de log nu per strike ook volume,
 open interest en expiratie in de vorm `strike [volume, open interest, expiry]`.
 

--- a/criteria.yaml
+++ b/criteria.yaml
@@ -3,6 +3,9 @@
 # Centrale bron voor alle kwantitatieve parameters
 # =========================
 
+# Tip: zet `EXPLAIN_FILTERS=true` of start met `--show-filter-stats` om te
+# zien hoeveel combinaties elke regel wegfiltert.
+
 # 1) GENERIC STRIKE FILTERS
 strike:
   delta_min: -0.80

--- a/docs/rules_cli.md
+++ b/docs/rules_cli.md
@@ -64,3 +64,19 @@ tomic rules reload
 - Maak altijd een back-up voordat je het bestand wijzigt.
 - Gebruik `tomic rules validate` om fouten te voorkomen voordat je
   applicaties start.
+
+## Filterstatistieken tonen
+
+Wil je begrijpen waarom een strategie geen resultaten oplevert? Start je
+analysetool met `--show-filter-stats` of stel `EXPLAIN_FILTERS=true` in je
+omgeving. Je ziet dan hoeveel kandidaten per regel zijn afgevallen:
+
+```
+$ tomic analysis --show-filter-stats
+min_rom            : 12
+delta_range        : 8
+market_data.volume : 3
+```
+
+Pas daarna de waarden in `criteria.yaml` of `tomic/strike_selection_rules.yaml`
+aan en valideer de wijzigingen met `tomic rules validate criteria.yaml --reload`.

--- a/tomic/strike_selection_rules.yaml
+++ b/tomic/strike_selection_rules.yaml
@@ -3,6 +3,9 @@
 # Per strategie selectie- en bouwregels (gealigneerd met criteria/vol-rules)
 # =========================
 
+# Debug: gebruik `--show-filter-stats` of `EXPLAIN_FILTERS=true` om te zien
+# hoeveel strikes per regel afvallen.
+
 default:
   method: spot_distance
   delta_range: [-1.0, 1.0]


### PR DESCRIPTION
## Summary
- document `--show-filter-stats` / `EXPLAIN_FILTERS` usage
- add filter statistics examples to README and rules docs
- mention filter debugging in criteria and strike selection configs

## Testing
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_b_68a2089aceb0832ea0517d2cabeb83c5