### PR TITLE
Handle invalid spot prices

### DIFF
--- a/tests/helpers/test_price_utils.py
+++ b/tests/helpers/test_price_utils.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from tomic.helpers import price_utils
+from tomic.journal.utils import save_json
+
+
+def test_load_latest_close_non_positive(monkeypatch, tmp_path):
+    """Non-positive close values should be returned as ``None``."""
+
+    data_dir = tmp_path / "prices"
+    data_dir.mkdir()
+    save_json([{"date": "2024-01-01", "close": -1}], data_dir / "AAA.json")
+
+    monkeypatch.setattr(price_utils, "cfg_get", lambda *a, **k: str(data_dir))
+
+    price, date = price_utils._load_latest_close("AAA")
+    assert price is None
+    assert date == "2024-01-01"
+

--- a/tomic/helpers/price_utils.py
+++ b/tomic/helpers/price_utils.py
@@ -19,6 +19,11 @@ def _load_latest_close(symbol: str) -> tuple[float | None, str | None]:
         try:
             price = float(rec.get("close"))
             date_str = str(rec.get("date"))
+            if price <= 0:
+                logger.debug(
+                    f"Ignoring non-positive close for {symbol} on {date_str}: {price}"
+                )
+                return None, date_str
             logger.debug(f"Using last close for {symbol} on {date_str}: {price}")
             return price, date_str
         except Exception:


### PR DESCRIPTION
## Summary
- Return `None` for non-positive close prices in `_load_latest_close`
- Add `_spot_from_chain` helper and spot validation in control panel
- Use option chain close when no valid spot price is available

## Testing
- `pytest tests/helpers/test_price_utils.py tests/cli/test_controlpanel_proposals.py::test_spot_from_chain_returns_value tests/cli/test_controlpanel_proposals.py::test_strategy_proposals_abort_on_missing_spot -q`

------
https://chatgpt.com/codex/tasks/task_b_68a485ee11a0832e82bcc847b3fb2c65