### PR TITLE
Refactor market info display

### DIFF
--- a/tests/cli/test_controlpanel_proposals.py
+++ b/tests/cli/test_controlpanel_proposals.py
@@ -82,7 +82,7 @@ def test_show_market_info(monkeypatch, tmp_path):
     prints = []
     monkeypatch.setattr(builtins, "print", lambda *a, **k: prints.append(" ".join(str(x) for x in a)))
 
-    inputs = iter(["5", "0", "7"])
+    inputs = iter(["5", "0", "7", "8"])
     monkeypatch.setattr(builtins, "input", lambda *a: next(inputs))
     mod.run_portfolio_menu()
 


### PR DESCRIPTION
## Summary
- Extract market data loading into `_load_market_rows`
- Add `show_informative_market_info` for tabulated market data
- Update analysis menu with option to show informative market info

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af4bcb204c832e913f879d974554a0