### PR TITLE
feat: enrich strategy alerts with exit signals

### DIFF
--- a/tests/cli/test_print_strategy_alerts.py
+++ b/tests/cli/test_print_strategy_alerts.py
@@ -1,4 +1,4 @@
-from tomic.cli.strategy_dashboard import print_strategy_alerts
+from tomic.cli.strategy_dashboard import generate_exit_alerts, print_strategy_alerts
 
 
 def test_print_strategy_alerts_dte(capsys):
@@ -7,3 +7,12 @@ def test_print_strategy_alerts_dte(capsys):
     captured = capsys.readouterr().out
     assert "⏳ 5 DTE" in captured
     assert "🚨 XYZ – Test" in captured
+
+
+def test_print_strategy_alerts_exit(capsys):
+    strategy = {"symbol": "XYZ", "type": "Test", "spot": 90.0}
+    rule = {"spot_below": 100}
+    generate_exit_alerts(strategy, rule)
+    print_strategy_alerts(strategy)
+    captured = capsys.readouterr().out
+    assert "onder exitniveau 100" in captured


### PR DESCRIPTION
## Summary
- add `generate_exit_alerts` helper to combine entry, existing and exit alerts
- use enriched `strategy['alerts']` in `print_strategy_full` and `print_strategy_alerts`
- update tests for new exit alert helper

## Testing
- `pytest tests/cli/test_print_strategy_alerts.py::test_print_strategy_alerts_exit -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b0959282f0832e9501d11de308296d