### PR TITLE
Add days-to-expiry exit alert to generate_exit_alerts

### DIFF
--- a/tests/cli/test_print_strategy.py
+++ b/tests/cli/test_print_strategy.py
@@ -1,4 +1,4 @@
-from tomic.cli.strategy_dashboard import print_strategy_full
+from tomic.cli.strategy_dashboard import generate_exit_alerts, print_strategy_full
 
 
 def test_print_strategy_spot_diff(capsys):
@@ -45,3 +45,12 @@ def test_print_strategy_exit_criteria(capsys):
     assert "🚪 EXITCRITERIA" in out
     assert "Stop" in out
     assert "Profit" in out
+
+
+def test_print_strategy_expiry_alert(capsys):
+    strat = {"symbol": "XYZ", "type": "Test", "days_to_expiry": 5}
+    rule = {"days_before_expiry": 10}
+    generate_exit_alerts(strat, rule)
+    print_strategy_full(strat)
+    out = capsys.readouterr().out
+    assert "⚠️ 5 DTE ≤ exitdrempel 10" in out

--- a/tests/cli/test_print_strategy_alerts.py
+++ b/tests/cli/test_print_strategy_alerts.py
@@ -16,3 +16,12 @@ def test_print_strategy_alerts_exit(capsys):
     print_strategy_alerts(strategy)
     captured = capsys.readouterr().out
     assert "onder exitniveau 100" in captured
+
+
+def test_print_strategy_alerts_expiry_rule(capsys):
+    strategy = {"symbol": "XYZ", "type": "Test", "days_to_expiry": 5}
+    rule = {"days_before_expiry": 10}
+    generate_exit_alerts(strategy, rule)
+    print_strategy_alerts(strategy)
+    captured = capsys.readouterr().out
+    assert "⚠️ 5 DTE ≤ exitdrempel 10" in captured

--- a/tomic/cli/strategy_dashboard.py
+++ b/tomic/cli/strategy_dashboard.py
@@ -228,6 +228,12 @@ def generate_exit_alerts(strategy: dict, rule: dict | None) -> None:
                 alerts.append(
                     f"🚨 PnL {profit_pct:.1f}% >= target {rule['target_profit_pct']:.1f}%"
                 )
+        dte = strategy.get("days_to_expiry")
+        dte_limit = rule.get("days_before_expiry")
+        if dte_limit and dte is not None and dte <= dte_limit:
+            alerts.append(
+                f"⚠️ {dte} DTE ≤ exitdrempel {dte_limit}"
+            )
     profile = ALERT_PROFILE.get(strategy.get("type"))
     if profile is not None:
         alerts = [a for a in alerts if alert_category(a) in profile]


### PR DESCRIPTION
## Summary
- warn when strategy approaches expiry based on exit rule
- test expiry alerts appear in full and alerts views

## Testing
- `pytest tests/cli/test_print_strategy.py::test_print_strategy_expiry_alert tests/cli/test_print_strategy_alerts.py::test_print_strategy_alerts_expiry_rule -q`

------
https://chatgpt.com/codex/tasks/task_b_68b098878118832e94f39c9721985227