### PR TITLE
Add structured exit rules to journal records

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ TOMIC is jouw persoonlijke handelsassistent voor het vinden van de beste optietr
 📈 Marketdata (spot, IV, skew, HV, ATR)
 💼 Portfolio-fit (Greeks, margin)
 🧠 TOMIC-strategie (PoS, EV, diversificatie)
-📓 Journaling (entry, exit, risk)
+📓 Journaling (entry, structured exit rules, risk)
 
 Geen automatische trading – TOMIC ondersteunt, jij beslist.
 

--- a/tests/cli/test_extract_exit_rules.py
+++ b/tests/cli/test_extract_exit_rules.py
@@ -1,0 +1,28 @@
+from tomic.cli.strategy_dashboard import extract_exit_rules
+from tomic.journal.utils import save_json
+
+
+def test_extract_exit_rules_reads_structured_object(tmp_path):
+    journal_path = tmp_path / "journal.json"
+    save_json(
+        [
+            {
+                "Symbool": "ABC",
+                "Expiry": "2024-01-19",
+                "Premium": 1.0,
+                "ExitRules": {
+                    "spot_below": 90.0,
+                    "spot_above": 110.0,
+                    "target_profit_pct": 50.0,
+                    "days_before_expiry": 7,
+                },
+            }
+        ],
+        journal_path,
+    )
+
+    rules = extract_exit_rules(str(journal_path))
+    key = ("ABC", "2024-01-19")
+    assert key in rules
+    assert rules[key]["spot_below"] == 90.0
+    assert rules[key]["target_profit_pct"] == 50.0

--- a/tomic/analysis/strategy.py
+++ b/tomic/analysis/strategy.py
@@ -395,6 +395,10 @@ def group_strategies(
 
             strat.update(parse_plan_metrics(trade_data.get("Plan", "")))
 
+            exit_rules = trade_data.get("ExitRules")
+            if isinstance(exit_rules, dict):
+                strat["exit_rules"] = exit_rules
+
             exit_text = trade_data.get("Exitstrategie")
             if exit_text:
                 strat["exit_strategy"] = exit_text

--- a/tomic/journal/journal_inspector.py
+++ b/tomic/journal/journal_inspector.py
@@ -103,6 +103,10 @@ def toon_details(trade: Dict[str, Any]) -> None:
             print("\n🚪 Exitstrategie:")
             for line in v.strip().splitlines():
                 print(f"  {line}")
+        elif k == "ExitRules":
+            print("\n🚪 ExitRules:")
+            for rk, rv in v.items():
+                print(f"  {rk}: {rv}")
         elif k == "Opmerkingen":
             print("\n🗒️ Opmerkingen:")
             for line in v.strip().splitlines():

--- a/tomic/journal/journal_updater.py
+++ b/tomic/journal/journal_updater.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import date
 
 from tomic.journal.service import add_trade, next_trade_id
+from tomic.models import ExitRules
 
 
 def float_prompt(prompt_tekst, default=None):
@@ -118,6 +119,19 @@ def interactieve_trade_invoer():
         lijnen.append(regel)
     exitstrategie = "\n".join(lijnen)
 
+    print("\nOptionele exit rules (leeg laten om over te slaan):")
+    spot_below = float_prompt("  Spot onder: ", default=None)
+    spot_above = float_prompt("  Spot boven: ", default=None)
+    target_profit_pct = float_prompt("  Target profit %: ", default=None)
+    dbe_input = input("  Dagen voor expiry: ").strip()
+    days_before_expiry = int(dbe_input) if dbe_input else None
+    exit_rules = ExitRules(
+        spot_below=spot_below,
+        spot_above=spot_above,
+        target_profit_pct=target_profit_pct,
+        days_before_expiry=days_before_expiry,
+    )
+
     # Skip automatic market data retrieval to avoid TWS calls
     metrics = {
         "spot_price": None,
@@ -177,6 +191,7 @@ def interactieve_trade_invoer():
         "Plan": plan,
         "Reden": reden,
         "Exitstrategie": exitstrategie,
+        "ExitRules": exit_rules.to_dict(),
         "Evaluatie": None,
         "Resultaat": None,
         "Opmerkingen": "",

--- a/tomic/models.py
+++ b/tomic/models.py
@@ -147,3 +147,32 @@ class OptionMetrics:
             open_interest=int(data.get("open_interest", 0) or 0),
         )
 
+
+@dataclass
+class ExitRules:
+    """Structured exit criteria for journal trades."""
+
+    spot_below: Optional[float] = None
+    spot_above: Optional[float] = None
+    target_profit_pct: Optional[float] = None
+    days_before_expiry: Optional[int] = None
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ExitRules":
+        """Create ``ExitRules`` from a mapping."""
+        return cls(
+            spot_below=data.get("spot_below"),
+            spot_above=data.get("spot_above"),
+            target_profit_pct=data.get("target_profit_pct"),
+            days_before_expiry=data.get("days_before_expiry"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return this record as a plain dictionary."""
+        return {
+            "spot_below": self.spot_below,
+            "spot_above": self.spot_above,
+            "target_profit_pct": self.target_profit_pct,
+            "days_before_expiry": self.days_before_expiry,
+        }
+


### PR DESCRIPTION
## Summary
- model ExitRules dataclass for structured trade exits
- store ExitRules in journal records and display in inspector
- use structured ExitRules in strategy dashboard

## Testing
- `pytest tests/cli/test_extract_exit_rules.py -q`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b09da13708832ea479a28125fba7cf