### PR TITLE
feat: add wing_width_points config for ATM iron butterfly

### DIFF
--- a/config/strategies.yaml
+++ b/config/strategies.yaml
@@ -25,7 +25,7 @@ strategies:
       # ATM short straddle + wings
       short_call_multiplier: [1.0, 1.5, 2.0]
       short_put_multiplier:  [1.0, 1.5, 2.0]
-      wing_width: 10
+      wing_width_points: [10]
       use_ATR: true
 
   short_put_spread:

--- a/tests/analysis/test_atm_iron_butterfly_migration.py
+++ b/tests/analysis/test_atm_iron_butterfly_migration.py
@@ -1,0 +1,30 @@
+import warnings
+
+from tomic.strategies import atm_iron_butterfly
+
+
+chain = [
+    {"expiry": "20250101", "strike": 100, "type": "C", "bid": 1.0, "ask": 1.2, "delta": 0.4, "edge": 0.1, "model": 1.0},
+    {"expiry": "20250101", "strike": 100, "type": "P", "bid": 1.0, "ask": 1.2, "delta": -0.4, "edge": 0.1, "model": 1.0},
+    {"expiry": "20250101", "strike": 105, "type": "C", "bid": 0.5, "ask": 0.7, "delta": 0.2, "edge": 0.1, "model": 1.0},
+    {"expiry": "20250101", "strike": 95, "type": "P", "bid": 0.5, "ask": 0.7, "delta": -0.2, "edge": 0.1, "model": 1.0},
+]
+
+
+def test_wing_width_deprecation():
+    cfg = {
+        "strategies": {
+            "atm_iron_butterfly": {
+                "strike_to_strategy_config": {
+                    "center_strike_relative_to_spot": [0],
+                    "wing_width": 5,
+                    "use_ATR": False,
+                }
+            }
+        }
+    }
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        props, _ = atm_iron_butterfly.generate("AAA", chain, cfg, 100.0, 1.0)
+        assert isinstance(props, list)
+        assert any("wing_width" in str(warn.message) for warn in w)

--- a/tomic/strategies/atm_iron_butterfly.py
+++ b/tomic/strategies/atm_iron_butterfly.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import Any, Dict, List
+import warnings
 import pandas as pd
 from tomic.bs_calculator import black_scholes
 from tomic.helpers.dateutils import dte_between_dates
@@ -127,7 +128,18 @@ def generate(
         return rr >= min_rr
 
     centers = rules.get("center_strike_relative_to_spot", [0])
-    widths = rules.get("wing_width_points", [])
+    widths = rules.get("wing_width_points")
+    if widths is None:
+        legacy = rules.get("wing_width")
+        if legacy is not None:
+            warnings.warn(
+                "'wing_width' is deprecated; use 'wing_width_points' instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            widths = [legacy]
+        else:
+            widths = []
     for c_off in centers:
         center = spot + (c_off * atr if use_atr else c_off)
         center = _nearest_strike(strike_map, expiry, "C", center).matched


### PR DESCRIPTION
## Summary
- replace `wing_width` with `wing_width_points` in ATM iron butterfly config
- support legacy `wing_width` in `atm_iron_butterfly.generate` with deprecation warning
- test fallback for legacy config

## Testing
- `pytest tests/analysis/test_atm_iron_butterfly_migration.py tests/analysis/test_strategy_modules.py`


------
https://chatgpt.com/codex/tasks/task_b_68b09df03c98832eb0e003c123756250