### PR TITLE
Replace wing width config with explicit long leg keys

### DIFF
--- a/config/strategies.yaml
+++ b/config/strategies.yaml
@@ -5,7 +5,9 @@ default:
   strike_to_strategy_config:
     short_call_multiplier: [1.5, 2.0, 2.5, 3.0, 3.5]
     short_put_multiplier:  [1.5, 2.0, 2.5, 3.0, 3.5]
-    wing_width: 5
+    long_call_distance_points: [5]
+    long_put_distance_points: [5]
+    long_leg_distance_points: [5]
     use_ATR: true
 
 strategies:
@@ -15,7 +17,8 @@ strategies:
     strike_to_strategy_config:
       short_call_multiplier: [1.5, 2.0, 2.5, 3.0, 3.5]
       short_put_multiplier:  [1.5, 2.0, 2.5, 3.0, 3.5]
-      wing_width: 5
+      long_call_distance_points: [5]
+      long_put_distance_points: [5]
       use_ATR: true
 
   atm_iron_butterfly:
@@ -33,7 +36,7 @@ strategies:
     strike_to_strategy_config:
       short_call_multiplier: [1.5, 2.0, 2.5]   # aanwezig voor uniformiteit (niet gebruikt)
       short_put_multiplier:  [1.5, 2.0, 2.5, 3.0]
-      wing_width: 5
+      long_put_distance_points: [5]
       use_ATR: true
 
   short_call_spread:
@@ -41,7 +44,7 @@ strategies:
     strike_to_strategy_config:
       short_call_multiplier: [1.5, 2.0, 2.5, 3.0]
       short_put_multiplier:  [1.5, 2.0, 2.5]   # aanwezig voor uniformiteit (niet gebruikt)
-      wing_width: 5
+      long_call_distance_points: [5]
       use_ATR: true
 
   naked_put:
@@ -49,15 +52,13 @@ strategies:
     strike_to_strategy_config:
       short_call_multiplier: [1.5, 2.0]        # aanwezig voor uniformiteit (niet gebruikt)
       short_put_multiplier:  [1.0, 1.5, 2.0, 2.5]
-      wing_width: 0                             # geen long wing
       use_ATR: true
 
   calendar:
-    # Calendar focust minder op ATR-wings; wing_width speelt niet
+    # Calendar focust minder op ATR-wings; long wings spelen niet
     strike_to_strategy_config:
       short_call_multiplier: [1.0]              # niet van toepassing maar verplicht aanwezig
       short_put_multiplier:  [1.0]
-      wing_width: 0
       use_ATR: false
       base_strikes_relative_to_spot: [5]       # basis-strike op spot (0 ATR); kan worden uitgebreid
       expiry_gap_min_days: 14
@@ -67,7 +68,7 @@ strategies:
     strike_to_strategy_config:
       short_call_multiplier: [1.5, 2.0, 2.5]    # voor call-variant
       short_put_multiplier:  [1.5, 2.0, 2.5]    # voor put-variant
-      wing_width: 5
+      long_leg_distance_points: [5]
       use_ATR: true
 
   backspread_put:
@@ -75,5 +76,5 @@ strategies:
     strike_to_strategy_config:
       short_call_multiplier: [1.5]              # aanwezig voor uniformiteit (niet gebruikt)
       short_put_multiplier:  [1.5, 2.0, 2.5]
-      wing_width: 5
+      long_put_distance_points: [5]
       use_ATR: true

--- a/tests/analysis/test_strategy_candidates_new.py
+++ b/tests/analysis/test_strategy_candidates_new.py
@@ -62,7 +62,8 @@ def test_generate_strategy_candidates_with_strings():
                 "strike_to_strategy_config": {
                     "short_call_multiplier": [10],
                     "short_put_multiplier": [10],
-                    "wing_width": 10,
+                    "long_call_distance_points": [10],
+                    "long_put_distance_points": [10],
                     "use_ATR": False,
                 }
             }
@@ -92,7 +93,8 @@ def test_generate_strategy_candidates_missing_metrics_reason():
                 "strike_to_strategy_config": {
                     "short_call_multiplier": [10],
                     "short_put_multiplier": [10],
-                    "wing_width": 10,
+                    "long_call_distance_points": [10],
+                    "long_put_distance_points": [10],
                     "use_ATR": False,
                 }
             }
@@ -162,7 +164,8 @@ def test_parity_mid_used_for_missing_bidask(monkeypatch):
                 "strike_to_strategy_config": {
                     "short_call_multiplier": [10],
                     "short_put_multiplier": [10],
-                    "wing_width": 10,
+                    "long_call_distance_points": [10],
+                    "long_put_distance_points": [10],
                     "use_ATR": False,
                 }
             }

--- a/tests/analysis/test_strategy_dynamic_config.py
+++ b/tests/analysis/test_strategy_dynamic_config.py
@@ -20,7 +20,8 @@ def test_generate_candidates_uses_global_config(monkeypatch):
                     "strike_to_strategy_config": {
                         "short_call_multiplier": [10],
                         "short_put_multiplier": [10],
-                        "wing_width": 10,
+                        "long_call_distance_points": [10],
+                        "long_put_distance_points": [10],
                         "use_ATR": False,
                     }
                 }

--- a/tomic/strategies/iron_condor.py
+++ b/tomic/strategies/iron_condor.py
@@ -132,12 +132,24 @@ def generate(
 
     calls = rules.get("short_call_multiplier", [])
     puts = rules.get("short_put_multiplier", [])
-    width = float(rules.get("wing_width", 0))
-    for c_mult, p_mult in islice(zip(calls, puts), 5):
+    call_widths = rules.get("long_call_distance_points")
+    put_widths = rules.get("long_put_distance_points")
+    if call_widths is None or put_widths is None:
+        legacy = rules.get("wing_width")
+        if legacy is not None:
+            if isinstance(legacy, list):
+                call_widths = put_widths = legacy
+            else:
+                call_widths = put_widths = [legacy]
+        else:
+            call_widths = put_widths = []
+    for c_mult, p_mult, c_w, p_w in islice(
+        zip(calls, puts, call_widths, put_widths), 5
+    ):
         sc_target = spot + (c_mult * atr if use_atr else c_mult)
         sp_target = spot - (p_mult * atr if use_atr else p_mult)
-        lc_target = sc_target + width
-        lp_target = sp_target - width
+        lc_target = sc_target + float(c_w)
+        lp_target = sp_target - float(p_w)
         sc = _nearest_strike(strike_map, expiry, "C", sc_target)
         sp = _nearest_strike(strike_map, expiry, "P", sp_target)
         lc = _nearest_strike(strike_map, expiry, "C", lc_target)


### PR DESCRIPTION
## Summary
- replace `wing_width` entries with `long_*_distance_points` lists
- adjust iron condor strategy to read new keys with fallback to `wing_width`
- update tests for new configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b14a1c839c832e83d4af79b7adb3eb