### PR TITLE
Rename wing_width to wing_width_points in strike rules

### DIFF
--- a/tomic/strategies/iron_condor.py
+++ b/tomic/strategies/iron_condor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import Any, Dict, List
 import math
+import warnings
 import pandas as pd
 from itertools import islice
 from tomic.bs_calculator import black_scholes
@@ -135,7 +136,15 @@ def generate(
     call_widths = rules.get("long_call_distance_points")
     put_widths = rules.get("long_put_distance_points")
     if call_widths is None or put_widths is None:
-        legacy = rules.get("wing_width")
+        legacy = rules.get("wing_width_points")
+        if legacy is None:
+            legacy = rules.get("wing_width")
+            if legacy is not None:
+                warnings.warn(
+                    "'wing_width' is deprecated; use 'wing_width_points' instead",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
         if legacy is not None:
             if isinstance(legacy, list):
                 call_widths = put_widths = legacy

--- a/tomic/strike_selection_rules.yaml
+++ b/tomic/strike_selection_rules.yaml
@@ -20,7 +20,7 @@ iron_condor:
   #iv_rank_min: 0.50              # align met portfolio.condor_gates & vol-rules
   #max_skew: 0.25                 # cap op extreme skew (units afhankelijk van jouw metriek)
   min_risk_reward: 1.5           # TOMIC-beleid al in selectie
-  wing_width: [5, 15]
+  wing_width_points: [5, 15]
 
 atm_iron_butterfly:
   method: spot_distance
@@ -28,7 +28,7 @@ atm_iron_butterfly:
   min_rom: 0.10
   #iv_rank_min: 0.25              # vol-rules laten tot 0.30 toe → 0.25–0.30 is sweet spot
   #max_skew: 0.25
-  wing_width: [3, 10]
+  wing_width_points: [3, 10]
 
 short_put_spread:
   method: delta


### PR DESCRIPTION
## Summary
- Rename `wing_width` entries to `wing_width_points` in strike selection rules
- Update iron condor strategy to read `wing_width_points` and warn when using deprecated `wing_width`

## Testing
- `pytest` *(fails: tests/api/test_market_client.py::test_security_def_option_parameter_records_multiplier)*

------
https://chatgpt.com/codex/tasks/task_b_68b1f91b937c832ea0cb60a35b409c1f