### PR TITLE
Validate width list configuration in strategies

### DIFF
--- a/tomic/strategies/atm_iron_butterfly.py
+++ b/tomic/strategies/atm_iron_butterfly.py
@@ -7,6 +7,7 @@ from tomic.helpers.dateutils import dte_between_dates
 from tomic.helpers.timeutils import today
 from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
 from . import StrategyName
+from .utils import validate_width_list
 from ..utils import get_option_mid_price, normalize_leg
 from ..logutils import log_combo_evaluation
 from ..config import get as cfg_get
@@ -140,6 +141,7 @@ def generate(
             widths = [legacy]
         else:
             widths = []
+    widths = list(validate_width_list(widths, "wing_width_points"))
     for c_off in centers:
         center = spot + (c_off * atr if use_atr else c_off)
         center = _nearest_strike(strike_map, expiry, "C", center).matched

--- a/tomic/strategies/backspread_put.py
+++ b/tomic/strategies/backspread_put.py
@@ -6,6 +6,7 @@ from tomic.helpers.dateutils import dte_between_dates
 from tomic.helpers.timeutils import today
 from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
 from . import StrategyName
+from .utils import validate_width_list
 from ..utils import get_option_mid_price, normalize_leg
 from ..logutils import log_combo_evaluation
 from ..config import get as cfg_get
@@ -132,7 +133,11 @@ def generate(
         or rules.get("short_delta_range")
         or []
     )
-    widths = rules.get("long_put_distance_points", [])
+    widths = list(
+        validate_width_list(
+            rules.get("long_put_distance_points"), "long_put_distance_points"
+        )
+    )
     min_gap = int(rules.get("expiry_gap_min_days", 0))
     pairs = select_expiry_pairs(expiries, min_gap)
     if len(delta_range) == 2:

--- a/tomic/strategies/iron_condor.py
+++ b/tomic/strategies/iron_condor.py
@@ -9,6 +9,7 @@ from tomic.helpers.dateutils import dte_between_dates
 from tomic.helpers.timeutils import today
 from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
 from . import StrategyName
+from .utils import validate_width_list
 from ..utils import get_option_mid_price, normalize_leg, normalize_right
 from ..logutils import logger
 from ..config import get as cfg_get
@@ -146,12 +147,15 @@ def generate(
                     stacklevel=2,
                 )
         if legacy is not None:
-            if isinstance(legacy, list):
-                call_widths = put_widths = legacy
-            else:
-                call_widths = put_widths = [legacy]
-        else:
-            call_widths = put_widths = []
+            if not isinstance(legacy, list):
+                legacy = [legacy]
+            if call_widths is None:
+                call_widths = legacy
+            if put_widths is None:
+                put_widths = legacy
+
+    call_widths = list(validate_width_list(call_widths, "long_call_distance_points"))
+    put_widths = list(validate_width_list(put_widths, "long_put_distance_points"))
     for c_mult, p_mult, c_w, p_w in islice(
         zip(calls, puts, call_widths, put_widths), 5
     ):

--- a/tomic/strategies/ratio_spread.py
+++ b/tomic/strategies/ratio_spread.py
@@ -7,6 +7,7 @@ from tomic.helpers.dateutils import dte_between_dates
 from tomic.helpers.timeutils import today
 from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
 from . import StrategyName
+from .utils import validate_width_list
 from ..utils import get_option_mid_price, normalize_leg, normalize_right
 from ..logutils import log_combo_evaluation
 from ..strategy_candidates import (
@@ -130,7 +131,11 @@ def generate(
         or rules.get("short_delta_range")
         or []
     )
-    widths = rules.get("long_leg_distance_points", [])
+    widths = list(
+        validate_width_list(
+            rules.get("long_leg_distance_points"), "long_leg_distance_points"
+        )
+    )
     if len(delta_range) == 2:
         calls_pre = []
         for opt in option_chain:

--- a/tomic/strategies/short_call_spread.py
+++ b/tomic/strategies/short_call_spread.py
@@ -6,6 +6,7 @@ from tomic.helpers.dateutils import dte_between_dates
 from tomic.helpers.timeutils import today
 from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
 from . import StrategyName
+from .utils import validate_width_list
 from ..utils import get_option_mid_price, normalize_leg
 from ..logutils import log_combo_evaluation
 from ..config import get as cfg_get
@@ -131,7 +132,11 @@ def generate(
         or rules.get("short_delta_range")
         or []
     )
-    widths = rules.get("long_call_distance_points", [])
+    widths = list(
+        validate_width_list(
+            rules.get("long_call_distance_points"), "long_call_distance_points"
+        )
+    )
     if len(delta_range) == 2:
         for width in widths[:5]:
             short_opt = None

--- a/tomic/strategies/short_put_spread.py
+++ b/tomic/strategies/short_put_spread.py
@@ -6,6 +6,7 @@ from tomic.helpers.dateutils import dte_between_dates
 from tomic.helpers.timeutils import today
 from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
 from . import StrategyName
+from .utils import validate_width_list
 from ..utils import get_option_mid_price, normalize_leg
 from ..logutils import log_combo_evaluation
 from ..config import get as cfg_get
@@ -131,7 +132,11 @@ def generate(
         or rules.get("short_delta_range")
         or []
     )
-    widths = rules.get("long_put_distance_points", [])
+    widths = list(
+        validate_width_list(
+            rules.get("long_put_distance_points"), "long_put_distance_points"
+        )
+    )
     if len(delta_range) == 2:
         for width in widths[:5]:
             short_opt = None

--- a/tomic/strategies/utils.py
+++ b/tomic/strategies/utils.py
@@ -1,0 +1,35 @@
+"""Utility helpers for strategy modules."""
+
+from __future__ import annotations
+
+from typing import Sequence, Any
+
+from ..logutils import logger
+
+
+def validate_width_list(widths: Sequence[Any] | None, key: str) -> Sequence[Any]:
+    """Return ``widths`` if valid or raise ``ValueError``.
+
+    Parameters
+    ----------
+    widths:
+        The sequence of width values retrieved from configuration.
+    key:
+        The configuration key the widths originate from. Used for a clear
+        error message when validation fails.
+
+    Raises
+    ------
+    ValueError
+        If ``widths`` is ``None`` or empty.
+    """
+
+    if not widths:
+        msg = f"'{key}' ontbreekt of is leeg in configuratie"
+        logger.error(msg)
+        raise ValueError(msg)
+    return widths
+
+
+__all__ = ["validate_width_list"]
+


### PR DESCRIPTION
## Summary
- add `validate_width_list` helper to ensure width list configuration keys are present and non-empty
- use helper in strategy `generate` functions (iron condor, iron butterfly, spreads, ratio, backspread)

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b2a21d7fb4832e80917848fc0a0564