### PR TITLE
Add trade management menu entry and module

### DIFF
--- a/tomic/cli/controlpanel.py
+++ b/tomic/cli/controlpanel.py
@@ -1829,6 +1829,10 @@ def run_portfolio_menu() -> None:
     menu.add("Trading Plan", lambda: run_module("tomic.cli.trading_plan"))
     menu.add("Portfolio ophalen en tonen", fetch_and_show)
     menu.add("Laatst opgehaalde portfolio tonen", show_saved)
+    menu.add(
+        "Trademanagement (controleer exitcriteria)",
+        lambda: run_module("tomic.cli.trade_management"),
+    )
     menu.add("Toon portfolio greeks", show_greeks)
     menu.add("Toon marktinformatie", show_market_info)
     menu.add("Earnings-informatie", lambda: run_module("tomic.cli.earnings_info"))

--- a/tomic/cli/trade_management.py
+++ b/tomic/cli/trade_management.py
@@ -1,0 +1,10 @@
+"""Placeholder module for trade management CLI utilities."""
+
+
+def main() -> None:
+    """Entry point for trade management tasks."""
+    print("Trade management module placeholder")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add trade management option to 📊 Analyse & Strategie control panel menu
- create placeholder `trade_management` CLI module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b2b45ae158832eaff2e523aa1bec47