### PR TITLE
Tabulate trade management overview and add tests

### DIFF
--- a/tests/test_controlpanel.py
+++ b/tests/test_controlpanel.py
@@ -1,0 +1,12 @@
+import builtins
+import importlib
+
+
+def test_portfolio_menu_option_calls_trade_management(monkeypatch):
+    mod = importlib.import_module("tomic.cli.controlpanel")
+    called = {}
+    monkeypatch.setattr(mod, "run_module", lambda name, *a: called.setdefault("name", name))
+    inputs = iter(["4", "9"])
+    monkeypatch.setattr(builtins, "input", lambda *a, **k: next(inputs))
+    mod.run_portfolio_menu()
+    assert called.get("name") == "tomic.cli.trade_management"

--- a/tests/test_trade_management.py
+++ b/tests/test_trade_management.py
@@ -1,0 +1,87 @@
+import builtins
+import importlib
+
+
+def _setup(monkeypatch, tmp_path, strategies):
+    tm = importlib.import_module("tomic.cli.trade_management")
+    positions = tmp_path / "positions.json"
+    journal = tmp_path / "journal.json"
+    positions.write_text("[]")
+    journal.write_text("[]")
+    monkeypatch.setattr(
+        tm,
+        "cfg_get",
+        lambda name, default=None: str(positions if name == "POSITIONS_FILE" else journal),
+    )
+    monkeypatch.setattr(tm, "group_strategies", lambda p, j: strategies)
+    monkeypatch.setattr(tm, "extract_exit_rules", lambda jf: {})
+    monkeypatch.setattr(tm, "generate_exit_alerts", lambda strat, rule: None)
+    return tm
+
+
+def test_exit_alert(monkeypatch, tmp_path, capsys):
+    strategies = [
+        {
+            "symbol": "AAA",
+            "type": "Strat",
+            "spot": 100,
+            "unrealizedPnL": 10,
+            "days_to_expiry": 5,
+            "alerts": ["exitniveau"],
+            "expiry": "",
+        }
+    ]
+    tm = _setup(monkeypatch, tmp_path, strategies)
+    tm.main()
+    out = capsys.readouterr().out
+    assert "=== 📊 TRADE MANAGEMENT ===" in out
+    assert "AAA" in out
+    assert "exitniveau" in out
+    assert "⚠️ Beheer nodig" in out
+
+
+def test_no_alert(monkeypatch, tmp_path, capsys):
+    strategies = [
+        {
+            "symbol": "AAA",
+            "type": "Strat",
+            "spot": 100,
+            "unrealizedPnL": 10,
+            "days_to_expiry": 5,
+            "alerts": [],
+            "expiry": "",
+        }
+    ]
+    tm = _setup(monkeypatch, tmp_path, strategies)
+    tm.main()
+    out = capsys.readouterr().out
+    assert "geen trigger" in out
+    assert "✅ Houden" in out
+
+
+def test_multiple_alerts(monkeypatch, tmp_path, capsys):
+    strategies = [
+        {
+            "symbol": "AAA",
+            "type": "Strat",
+            "spot": 100,
+            "unrealizedPnL": 10,
+            "days_to_expiry": 5,
+            "alerts": ["exitniveau", "PnL"],
+            "expiry": "",
+        },
+        {
+            "symbol": "BBB",
+            "type": "Strat",
+            "spot": 200,
+            "unrealizedPnL": -5,
+            "days_to_expiry": 10,
+            "alerts": ["DTE ≤ exitdrempel"],
+            "expiry": "",
+        },
+    ]
+    tm = _setup(monkeypatch, tmp_path, strategies)
+    tm.main()
+    out = capsys.readouterr().out
+    assert out.count("⚠️ Beheer nodig") == 2
+    assert "exitniveau | PnL" in out


### PR DESCRIPTION
## Summary
- Format trade-management output as a tabulated table with headers for index, symbol, strategy, spot, PnL, DTE, trigger and status
- Test trade-management scenarios for exit alerts, no alerts and multiple alerts
- Ensure portfolio menu option 4 launches the trade management module

## Testing
- `pytest tests/test_trade_management.py tests/test_controlpanel.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b2b8d7cf04832e9697fbba5bbe8499