### PR TITLE
Support flat strike configuration layout

### DIFF
--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -17,3 +17,12 @@ def test_falls_back_to_default():
     }
     result = loader.load_strike_config("unknown", config)
     assert result == {"foo": 1}
+
+
+def test_flat_mapping_support():
+    config = {
+        "default": {"foo": 1},
+        "s1": {"foo": 2},
+    }
+    assert loader.load_strike_config("s1", config) == {"foo": 2}
+    assert loader.load_strike_config("unknown", config) == {"foo": 1}

--- a/tests/test_strike_rules_loader.py
+++ b/tests/test_strike_rules_loader.py
@@ -4,33 +4,59 @@ from tomic import config, loader
 import pytest
 
 
-def _write_yaml(path):
-    path.write_text(textwrap.dedent(
-        """
-        default:
-          enabled: true
-          flags:
-            - A
-            - B
-          nested:
-            threshold:
-              min: 5
-        strategies:
-          s1:
-            enabled: false
-            flags:
-              - C
-            nested:
-              threshold:
-                min: 10
-        """
-    ))
+def _write_yaml_with_strategies(path):
+    path.write_text(
+        textwrap.dedent(
+            """
+            default:
+              enabled: true
+              flags:
+                - A
+                - B
+              nested:
+                threshold:
+                  min: 5
+            strategies:
+              s1:
+                enabled: false
+                flags:
+                  - C
+                nested:
+                  threshold:
+                    min: 10
+            """
+        )
+    )
+
+
+def _write_flat_yaml(path):
+    path.write_text(
+        textwrap.dedent(
+            """
+            default:
+              enabled: true
+              flags:
+                - A
+                - B
+              nested:
+                threshold:
+                  min: 5
+            s1:
+              enabled: false
+              flags:
+                - C
+              nested:
+                threshold:
+                  min: 10
+            """
+        )
+    )
 
 
 def test_yaml_loader_parses_nested_structures(tmp_path):
     pytest.importorskip("yaml")
     yaml_path = tmp_path / "strike_selection_rules.yaml"
-    _write_yaml(yaml_path)
+    _write_yaml_with_strategies(yaml_path)
 
     data = config._load_yaml(yaml_path)
     assert data["default"]["enabled"] is True
@@ -39,10 +65,25 @@ def test_yaml_loader_parses_nested_structures(tmp_path):
     assert data["strategies"]["s1"]["enabled"] is False
 
 
-def test_load_strike_config_with_yaml(tmp_path):
+def test_load_strike_config_with_strategies_yaml(tmp_path):
     pytest.importorskip("yaml")
     yaml_path = tmp_path / "strike_selection_rules.yaml"
-    _write_yaml(yaml_path)
+    _write_yaml_with_strategies(yaml_path)
+
+    data = config._load_yaml(yaml_path)
+    result = loader.load_strike_config("s1", data)
+    assert result["enabled"] is False
+    assert result["flags"] == ["C"]
+    assert result["nested"]["threshold"]["min"] == 10
+
+    result = loader.load_strike_config("unknown", data)
+    assert result["enabled"] is True
+
+
+def test_load_strike_config_with_flat_yaml(tmp_path):
+    pytest.importorskip("yaml")
+    yaml_path = tmp_path / "strike_selection_rules.yaml"
+    _write_flat_yaml(yaml_path)
 
     data = config._load_yaml(yaml_path)
     result = loader.load_strike_config("s1", data)

--- a/tomic/analysis/proposal_engine.py
+++ b/tomic/analysis/proposal_engine.py
@@ -178,10 +178,7 @@ def _calc_metrics(strategy: str, legs: List[Leg], spot_price: float) -> Dict[str
 def _filter_chain_by_dte(chain: List[Leg], strategy: str) -> List[Leg]:
     """Return ``chain`` filtered to the strategy's DTE range."""
 
-    try:
-        rules = load_strike_config(strategy, _STRIKE_RULES)
-    except Exception:
-        rules = {}
+    rules = load_strike_config(strategy, _STRIKE_RULES)
     dte_range = rules.get("dte_range")
     if not dte_range:
         return chain

--- a/tomic/loader.py
+++ b/tomic/loader.py
@@ -4,6 +4,21 @@ from __future__ import annotations
 
 
 def load_strike_config(strategy_name: str, config: dict) -> dict:
-    """Return strike config for ``strategy_name`` with ``default`` fallback."""
+    """Return strike config for ``strategy_name`` with ``default`` fallback.
 
-    return config["strategies"].get(strategy_name, config["default"])
+    ``config`` can be structured in two ways:
+
+    1. ``{"default": {...}, "strategies": {"s1": {...}}}``
+    2. ``{"default": {...}, "s1": {...}}``
+
+    This helper detects the layout and returns the rule set for ``strategy_name``
+    or falls back to ``default`` when not found. Missing keys simply return an
+    empty dict so callers don't need defensive ``try`` blocks.
+    """
+
+    if "strategies" in config:
+        rules = config["strategies"].get(strategy_name, config.get("default", {}))
+    else:
+        rules = config.get(strategy_name, config.get("default", {}))
+
+    return rules or {}


### PR DESCRIPTION
## Summary
- allow strike rule loader to handle direct mappings or nested `strategies`
- simplify proposal engine DTE filtering by relying on loader defaults
- add tests for both YAML layouts and flat mapping support

## Testing
- `pytest tomic/tests/test_loader.py tomic/tests/test_strike_rules_loader.py tomic/tests/analysis/test_proposal_engine.py`

------
https://chatgpt.com/codex/tasks/task_b_68b401cc11ac832e8abc59dbacdae46f