### PR TITLE
Normalize strike rule field names

### DIFF
--- a/tests/analysis/test_strike_rule_field_normalization.py
+++ b/tests/analysis/test_strike_rule_field_normalization.py
@@ -1,0 +1,46 @@
+import os
+from tomic import loader
+from tomic.strategies import calendar, ratio_spread
+
+
+def _calendar_chain():
+    return [
+        {"expiry": "2025-01-01", "strike": 100, "type": "C", "bid": 1, "ask": 1.2, "delta": 0.4, "edge": 0.1, "iv": 0.2, "model": 1.5},
+        {"expiry": "2025-02-01", "strike": 100, "type": "C", "bid": 1, "ask": 1.1, "delta": 0.3, "edge": 0.1, "iv": 0.25, "model": 1.3},
+        {"expiry": "2025-03-01", "strike": 105, "type": "C", "bid": 1, "ask": 1.3, "delta": 0.2, "edge": 0.1, "iv": 0.3, "model": 1.4},
+    ]
+
+
+def _ratio_chain():
+    return [
+        {"expiry": "20250101", "strike": 110, "type": "C", "bid": 1.4, "ask": 1.6, "delta": 0.4, "edge": 0.2, "model": 1.7},
+        {"expiry": "20250101", "strike": 120, "type": "C", "bid": 0.3, "ask": 0.5, "delta": 0.25, "edge": 0.1, "model": 0.55},
+        {"expiry": "20250101", "strike": 130, "type": "C", "bid": 0.1, "ask": 0.2, "delta": 0.1, "edge": 0.05, "model": 0.22},
+    ]
+
+
+def test_calendar_field_compat(monkeypatch):
+    monkeypatch.setenv("TOMIC_TODAY", "2024-06-01")
+    chain = _calendar_chain()
+    old_cfg = {"calendar": {"strike_distance": [0], "expiry_gap_min": 20, "dte_range": [20, 80]}}
+    new_cfg = {"calendar": {"base_strikes_relative_to_spot": [0], "expiry_gap_min_days": 20, "dte_range": [20, 80]}}
+    rules_old = loader.load_strike_config("calendar", old_cfg)
+    rules_new = loader.load_strike_config("calendar", new_cfg)
+    cfg_old = {"strategies": {"calendar": {"strike_to_strategy_config": rules_old}}}
+    cfg_new = {"strategies": {"calendar": {"strike_to_strategy_config": rules_new}}}
+    props_old, _ = calendar.generate("AAA", chain, cfg_old, 100.0, 1.0)
+    props_new, _ = calendar.generate("AAA", chain, cfg_new, 100.0, 1.0)
+    assert props_old == props_new
+
+
+def test_ratio_spread_field_compat():
+    chain = _ratio_chain()
+    old_cfg = {"ratio_spread": {"short_delta_range": [0.3, 0.45], "long_leg_distance": [10], "use_ATR": False}}
+    new_cfg = {"ratio_spread": {"short_delta_range": [0.3, 0.45], "long_leg_distance_points": [10], "use_ATR": False}}
+    rules_old = loader.load_strike_config("ratio_spread", old_cfg)
+    rules_new = loader.load_strike_config("ratio_spread", new_cfg)
+    cfg_old = {"strategies": {"ratio_spread": {"strike_to_strategy_config": rules_old}}}
+    cfg_new = {"strategies": {"ratio_spread": {"strike_to_strategy_config": rules_new}}}
+    props_old, _ = ratio_spread.generate("AAA", chain, cfg_old, 100.0, 1.0)
+    props_new, _ = ratio_spread.generate("AAA", chain, cfg_new, 100.0, 1.0)
+    assert props_old == props_new

--- a/tomic/loader.py
+++ b/tomic/loader.py
@@ -3,6 +3,23 @@
 from __future__ import annotations
 
 
+def normalize_strike_rule_fields(rules: dict) -> dict:
+    """Return ``rules`` with deprecated keys mapped to canonical names."""
+
+    mapping = {
+        "long_leg_distance": "long_leg_distance_points",
+        "strike_distance": "base_strikes_relative_to_spot",
+        "expiry_gap_min": "expiry_gap_min_days",
+    }
+    normalized = dict(rules)
+    for old, new in mapping.items():
+        if old in normalized and new not in normalized:
+            normalized[new] = normalized.pop(old)
+        else:
+            normalized.pop(old, None)
+    return normalized
+
+
 def load_strike_config(strategy_name: str, config: dict) -> dict:
     """Return strike config for ``strategy_name`` with ``default`` fallback.
 
@@ -21,4 +38,4 @@ def load_strike_config(strategy_name: str, config: dict) -> dict:
     else:
         rules = config.get(strategy_name, config.get("default", {}))
 
-    return rules or {}
+    return normalize_strike_rule_fields(rules or {})

--- a/tomic/strike_selection_rules.yaml
+++ b/tomic/strike_selection_rules.yaml
@@ -38,7 +38,7 @@ short_put_spread:
   #iv_rank_min: 0.50                   # align met vol-rules (hogere IV vereist)
   #max_skew: 0.25
   min_risk_reward: 0.4
-  long_leg_distance: [2, 7]
+  long_leg_distance_points: [2, 7]
 
 short_call_spread:
   method: delta
@@ -48,7 +48,7 @@ short_call_spread:
   #iv_rank_min: 0.50                   # align met vol-rules
   #max_skew: 0.25
   min_risk_reward: 0.6
-  long_leg_distance: [2, 7]
+  long_leg_distance_points: [2, 7]
 
 naked_put:
   method: delta
@@ -60,9 +60,9 @@ naked_put:
 
 calendar:
   method: spot_distance
-  strike_distance: 0                  # ATM bias
+  base_strikes_relative_to_spot: 0    # ATM bias
   dte_range: [20, 80]
-  expiry_gap_min: 10
+  expiry_gap_min_days: 10
   #iv_rank_max: 0.40                   # align met portfolio.calendar_gates & vol-rules
   #iv_percentile_max: 0.40
   #max_skew: 0.25


### PR DESCRIPTION
## Summary
- normalize legacy strike rule keys to canonical names when loading configurations
- update strike selection rules to use long_leg_distance_points, base_strikes_relative_to_spot, and expiry_gap_min_days
- add regression tests to ensure old field names still yield the same proposals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b4033d1e60832eb8657e59dab90105