### PR TITLE
Add helper to normalize legacy strategy config fields

### DIFF
--- a/tests/analysis/test_strategy_modules.py
+++ b/tests/analysis/test_strategy_modules.py
@@ -8,6 +8,33 @@ from tomic.strategies import StrategyName
 strategies = [
     (
         StrategyName.NAKED_PUT,
+        {"strike_to_strategy_config": {"short_put_delta_range": [-0.3, -0.25], "use_ATR": False}},
+    ),
+    (
+        StrategyName.SHORT_PUT_SPREAD,
+        {"strike_to_strategy_config": {"short_put_delta_range": [-0.35, -0.2], "long_put_distance_points": [5], "use_ATR": False}},
+    ),
+    (
+        StrategyName.SHORT_CALL_SPREAD,
+        {"strike_to_strategy_config": {"short_call_delta_range": [0.2, 0.35], "long_call_distance_points": [5], "use_ATR": False}},
+    ),
+    (
+        StrategyName.RATIO_SPREAD,
+        {"strike_to_strategy_config": {"short_leg_delta_range": [0.3, 0.45], "long_leg_distance_points": [5], "use_ATR": False}},
+    ),
+    (
+        StrategyName.BACKSPREAD_PUT,
+        {"strike_to_strategy_config": {"short_put_delta_range": [0.15, 0.3], "long_put_distance_points": [5], "use_ATR": False}},
+    ),
+    (
+        StrategyName.ATM_IRON_BUTTERFLY,
+        {"strike_to_strategy_config": {"center_strike_relative_to_spot": [0], "wing_width_points": [5], "use_ATR": False}},
+    ),
+]
+
+legacy_strategies = [
+    (
+        StrategyName.NAKED_PUT,
         {"strike_to_strategy_config": {"short_delta_range": [-0.3, -0.25], "use_ATR": False}},
     ),
     (
@@ -28,7 +55,7 @@ strategies = [
     ),
     (
         StrategyName.ATM_IRON_BUTTERFLY,
-        {"strike_to_strategy_config": {"center_strike_relative_to_spot": [0], "wing_width_points": [5], "use_ATR": False}},
+        {"strike_to_strategy_config": {"center_strike_relative_to_spot": [0], "wing_width": 5, "use_ATR": False}},
     ),
 ]
 
@@ -48,6 +75,14 @@ def test_strategy_modules_smoke(name, cfg):
     assert isinstance(props, list)
 
 
+@pytest.mark.parametrize("name,cfg", legacy_strategies)
+def test_strategy_modules_legacy_keys_warn(name, cfg):
+    mod = importlib.import_module(f"tomic.strategies.{name.value}")
+    with pytest.warns(DeprecationWarning):
+        props, _ = mod.generate("AAA", chain, cfg, 100.0, 1.0)
+    assert isinstance(props, list)
+
+
 def test_strategy_uses_default_block(monkeypatch):
     mod = importlib.import_module("tomic.strategies.naked_put")
     captured: dict = {}
@@ -62,7 +97,7 @@ def test_strategy_uses_default_block(monkeypatch):
         "strategies": {
             "naked_put": {
                 "strike_to_strategy_config": {
-                    "short_delta_range": [-0.3, -0.25],
+                    "short_put_delta_range": [-0.3, -0.25],
                     "use_ATR": False,
                 }
             }

--- a/tomic/strategies/backspread_put.py
+++ b/tomic/strategies/backspread_put.py
@@ -19,6 +19,7 @@ from ..strategy_candidates import (
     _validate_ratio,
     select_expiry_pairs,
 )
+from .config_normalizer import normalize_config
 
 
 def generate(
@@ -29,6 +30,7 @@ def generate(
     atr: float,
 ) -> tuple[List[StrategyProposal], list[str]]:
     rules = config.get("strike_to_strategy_config", {})
+    normalize_config(rules, {"short_delta_range": ("short_put_delta_range", None)})
     use_atr = bool(rules.get("use_ATR"))
     if spot is None:
         raise ValueError("spot price is required")
@@ -127,11 +129,7 @@ def generate(
             return True
         return rr >= min_rr
 
-    delta_range = (
-        rules.get("short_put_delta_range")
-        or rules.get("short_delta_range")
-        or []
-    )
+    delta_range = rules.get("short_put_delta_range") or []
     widths = list(
         validate_width_list(
             rules.get("long_put_distance_points"), "long_put_distance_points"

--- a/tomic/strategies/config_normalizer.py
+++ b/tomic/strategies/config_normalizer.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Mapping, Tuple
+import warnings
+
+MappingType = Mapping[str, Tuple[str, Callable[[Any], Any] | None]]
+
+
+def normalize_config(rules: Dict[str, Any], mapping: MappingType) -> None:
+    """Normalize legacy configuration fields.
+
+    Parameters
+    ----------
+    rules:
+        Configuration dictionary to normalize in place.
+    mapping:
+        Dictionary mapping legacy keys to tuples of (new_key, transform).
+        The transform callable, if provided, is applied to the value before
+        assigning it to the new key.
+    """
+    for old, (new, transform) in mapping.items():
+        if old in rules and new not in rules:
+            val = rules.pop(old)
+            if transform:
+                val = transform(val)
+            warnings.warn(
+                f"'{old}' is deprecated; use '{new}' instead",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            rules[new] = val
+
+
+__all__ = ["normalize_config"]

--- a/tomic/strategies/naked_put.py
+++ b/tomic/strategies/naked_put.py
@@ -13,6 +13,7 @@ from ..strategy_candidates import (
     _build_strike_map,
     _metrics,
 )
+from .config_normalizer import normalize_config
 
 
 def generate(
@@ -23,6 +24,7 @@ def generate(
     atr: float,
 ) -> tuple[List[StrategyProposal], list[str]]:
     rules = config.get("strike_to_strategy_config", {})
+    normalize_config(rules, {"short_delta_range": ("short_put_delta_range", None)})
     use_atr = bool(rules.get("use_ATR"))
     if spot is None:
         raise ValueError("spot price is required")
@@ -120,11 +122,7 @@ def generate(
             return True
         return rr >= min_rr
 
-    delta_range = (
-        rules.get("short_put_delta_range")
-        or rules.get("short_delta_range")
-        or []
-    )
+    delta_range = rules.get("short_put_delta_range") or []
     if len(delta_range) == 2:
         for opt in option_chain:
             if (

--- a/tomic/strategies/ratio_spread.py
+++ b/tomic/strategies/ratio_spread.py
@@ -18,6 +18,7 @@ from ..strategy_candidates import (
     _metrics,
     _validate_ratio,
 )
+from .config_normalizer import normalize_config
 
 
 def generate(
@@ -28,6 +29,7 @@ def generate(
     atr: float,
 ) -> tuple[List[StrategyProposal], list[str]]:
     rules = config.get("strike_to_strategy_config", {})
+    normalize_config(rules, {"short_delta_range": ("short_leg_delta_range", None)})
     use_atr = bool(rules.get("use_ATR"))
     if spot is None:
         raise ValueError("spot price is required")
@@ -125,11 +127,7 @@ def generate(
             return True
         return rr >= min_rr
 
-    delta_range = (
-        rules.get("short_leg_delta_range")
-        or rules.get("short_delta_range")
-        or []
-    )
+    delta_range = rules.get("short_leg_delta_range") or []
     widths = list(
         validate_width_list(
             rules.get("long_leg_distance_points"), "long_leg_distance_points"

--- a/tomic/strategies/short_call_spread.py
+++ b/tomic/strategies/short_call_spread.py
@@ -17,6 +17,7 @@ from ..strategy_candidates import (
     _find_option,
     _metrics,
 )
+from .config_normalizer import normalize_config
 
 
 def generate(
@@ -27,6 +28,7 @@ def generate(
     atr: float,
 ) -> tuple[List[StrategyProposal], list[str]]:
     rules = config.get("strike_to_strategy_config", {})
+    normalize_config(rules, {"short_delta_range": ("short_call_delta_range", None)})
     use_atr = bool(rules.get("use_ATR"))
     if spot is None:
         raise ValueError("spot price is required")
@@ -126,11 +128,7 @@ def generate(
             return True
         return rr >= min_rr
 
-    delta_range = (
-        rules.get("short_call_delta_range")
-        or rules.get("short_delta_range")
-        or []
-    )
+    delta_range = rules.get("short_call_delta_range") or []
     widths = list(
         validate_width_list(
             rules.get("long_call_distance_points"), "long_call_distance_points"

--- a/tomic/strategies/short_put_spread.py
+++ b/tomic/strategies/short_put_spread.py
@@ -17,6 +17,7 @@ from ..strategy_candidates import (
     _find_option,
     _metrics,
 )
+from .config_normalizer import normalize_config
 
 
 def generate(
@@ -27,6 +28,7 @@ def generate(
     atr: float,
 ) -> tuple[List[StrategyProposal], list[str]]:
     rules = config.get("strike_to_strategy_config", {})
+    normalize_config(rules, {"short_delta_range": ("short_put_delta_range", None)})
     use_atr = bool(rules.get("use_ATR"))
     if spot is None:
         raise ValueError("spot price is required")
@@ -126,11 +128,7 @@ def generate(
             return True
         return rr >= min_rr
 
-    delta_range = (
-        rules.get("short_put_delta_range")
-        or rules.get("short_delta_range")
-        or []
-    )
+    delta_range = rules.get("short_put_delta_range") or []
     widths = list(
         validate_width_list(
             rules.get("long_put_distance_points"), "long_put_distance_points"


### PR DESCRIPTION
## Summary
- normalize legacy strategy configuration keys and issue DeprecationWarnings
- use normalizer in strategy `generate` functions
- test legacy config keys produce warnings

## Testing
- `pytest tests/analysis/test_strategy_modules.py`

------
https://chatgpt.com/codex/tasks/task_b_68b41cc8a9d8832e8a639d22c871c022