### PR TITLE
Remove unused strike rule fields

### DIFF
--- a/tests/analysis/test_strategy_rule_field_absence.py
+++ b/tests/analysis/test_strategy_rule_field_absence.py
@@ -1,0 +1,22 @@
+import yaml
+from pathlib import Path
+
+RULES_FILE = Path(__file__).resolve().parents[2] / "tomic" / "strike_selection_rules.yaml"
+
+
+def _load_rules() -> dict:
+    with open(RULES_FILE, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def test_ratio_spread_fields_absent():
+    rules = _load_rules()
+    cfg = rules.get("ratio_spread", {})
+    assert "require_skew" not in cfg
+    assert "allow_extra_wings" not in cfg
+
+
+def test_backspread_put_fields_absent():
+    rules = _load_rules()
+    cfg = rules.get("backspread_put", {})
+    assert "require_term_compression" not in cfg

--- a/tomic/strike_selection_rules.yaml
+++ b/tomic/strike_selection_rules.yaml
@@ -73,9 +73,6 @@ ratio_spread:
   short_delta_range: [0.25, 0.45]
   dte_range: [20, 45]
   #iv_rank_min: 0.30                   # align met vol-rules (0.3–0.6)
-  require_skew: true
-  #min_skew: 5.0                       # align met vol-rules (units zoals in jouw skew-metriek)
-  allow_extra_wings: true
 
 backspread_put:
   method: delta
@@ -85,5 +82,4 @@ backspread_put:
   #iv_percentile_max: 0.40
   #skew_max: -2.0                      # vereis duidelijke put-skew (negatief)
   min_risk_reward: 0.6
-  require_term_compression: true
   ratio: "1x short / 2x long"


### PR DESCRIPTION
## Summary
- drop obsolete strike rule fields (require_skew, allow_extra_wings, require_term_compression)
- test that ratio spread and backspread put configs no longer expose those fields

## Testing
- `python -m pytest tests/analysis/test_strategy_rule_field_absence.py`


------
https://chatgpt.com/codex/tasks/task_b_68b47fcd2e28832ebadbe173a27c945d