### PR TITLE
Centralize strike rule field normalization

### DIFF
--- a/tests/analysis/test_atm_iron_butterfly_migration.py
+++ b/tests/analysis/test_atm_iron_butterfly_migration.py
@@ -1,5 +1,6 @@
 import warnings
 
+from tomic import loader
 from tomic.strategies import atm_iron_butterfly
 
 
@@ -12,15 +13,16 @@ chain = [
 
 
 def test_wing_width_deprecation():
-    cfg = {
-        "strike_to_strategy_config": {
-            "center_strike_relative_to_spot": [0],
-            "wing_width": 5,
-            "use_ATR": False,
-        }
+    rules_cfg = {
+        "center_strike_relative_to_spot": [0],
+        "wing_width": 5,
+        "use_ATR": False,
     }
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        props, _ = atm_iron_butterfly.generate("AAA", chain, cfg, 100.0, 1.0)
+        rules = loader.load_strike_config("atm_iron_butterfly", {"atm_iron_butterfly": rules_cfg})
+        props, _ = atm_iron_butterfly.generate(
+            "AAA", chain, {"strike_to_strategy_config": rules}, 100.0, 1.0
+        )
         assert isinstance(props, list)
         assert any("wing_width" in str(warn.message) for warn in w)

--- a/tests/analysis/test_strategy_modules.py
+++ b/tests/analysis/test_strategy_modules.py
@@ -2,6 +2,7 @@ import importlib
 
 import pytest
 
+from tomic import loader
 from tomic.strategy_candidates import generate_strategy_candidates
 from tomic.strategies import StrategyName
 
@@ -35,27 +36,27 @@ strategies = [
 legacy_strategies = [
     (
         StrategyName.NAKED_PUT,
-        {"strike_to_strategy_config": {"short_delta_range": [-0.3, -0.25], "use_ATR": False}},
+        {"short_delta_range": [-0.3, -0.25], "use_ATR": False},
     ),
     (
         StrategyName.SHORT_PUT_SPREAD,
-        {"strike_to_strategy_config": {"short_delta_range": [-0.35, -0.2], "long_put_distance_points": [5], "use_ATR": False}},
+        {"short_delta_range": [-0.35, -0.2], "long_put_distance_points": [5], "use_ATR": False},
     ),
     (
         StrategyName.SHORT_CALL_SPREAD,
-        {"strike_to_strategy_config": {"short_delta_range": [0.2, 0.35], "long_call_distance_points": [5], "use_ATR": False}},
+        {"short_delta_range": [0.2, 0.35], "long_call_distance_points": [5], "use_ATR": False},
     ),
     (
         StrategyName.RATIO_SPREAD,
-        {"strike_to_strategy_config": {"short_delta_range": [0.3, 0.45], "long_leg_distance_points": [5], "use_ATR": False}},
+        {"short_delta_range": [0.3, 0.45], "long_leg_distance": [5], "use_ATR": False},
     ),
     (
         StrategyName.BACKSPREAD_PUT,
-        {"strike_to_strategy_config": {"short_delta_range": [0.15, 0.3], "long_put_distance_points": [5], "use_ATR": False}},
+        {"short_delta_range": [0.15, 0.3], "long_put_distance_points": [5], "use_ATR": False},
     ),
     (
         StrategyName.ATM_IRON_BUTTERFLY,
-        {"strike_to_strategy_config": {"center_strike_relative_to_spot": [0], "wing_width": 5, "use_ATR": False}},
+        {"center_strike_relative_to_spot": [0], "wing_width": 5, "use_ATR": False},
     ),
 ]
 
@@ -75,11 +76,14 @@ def test_strategy_modules_smoke(name, cfg):
     assert isinstance(props, list)
 
 
-@pytest.mark.parametrize("name,cfg", legacy_strategies)
-def test_strategy_modules_legacy_keys_warn(name, cfg):
+@pytest.mark.parametrize("name,rules", legacy_strategies)
+def test_strategy_modules_legacy_keys_warn(name, rules):
     mod = importlib.import_module(f"tomic.strategies.{name.value}")
     with pytest.warns(DeprecationWarning):
-        props, _ = mod.generate("AAA", chain, cfg, 100.0, 1.0)
+        normalized = loader.load_strike_config(name.value, {name.value: rules})
+    props, _ = mod.generate(
+        "AAA", chain, {"strike_to_strategy_config": normalized}, 100.0, 1.0
+    )
     assert isinstance(props, list)
 
 

--- a/tests/analysis/test_strike_rule_field_normalization.py
+++ b/tests/analysis/test_strike_rule_field_normalization.py
@@ -1,46 +1,46 @@
-import os
+import pytest
+
 from tomic import loader
-from tomic.strategies import calendar, ratio_spread
+
+CASES = {
+    "calendar": (
+        {"strike_distance": 0, "expiry_gap_min": 20},
+        {"base_strikes_relative_to_spot": [0], "expiry_gap_min_days": 20},
+    ),
+    "ratio_spread": (
+        {"short_delta_range": [0.3, 0.45], "long_leg_distance": [10]},
+        {"short_leg_delta_range": [0.3, 0.45], "long_leg_distance_points": [10]},
+    ),
+    "naked_put": (
+        {"short_delta_range": [-0.3, -0.25]},
+        {"short_put_delta_range": [-0.3, -0.25]},
+    ),
+    "short_put_spread": (
+        {"short_delta_range": [-0.35, -0.2]},
+        {"short_put_delta_range": [-0.35, -0.2]},
+    ),
+    "backspread_put": (
+        {"short_delta_range": [0.15, 0.3]},
+        {"short_put_delta_range": [0.15, 0.3]},
+    ),
+    "short_call_spread": (
+        {"short_delta_range": [0.2, 0.35]},
+        {"short_call_delta_range": [0.2, 0.35]},
+    ),
+    "atm_iron_butterfly": (
+        {"wing_width": 5},
+        {"wing_width_points": [5]},
+    ),
+    "iron_condor": (
+        {"wing_width": [5]},
+        {"wing_width_points": [5]},
+    ),
+}
 
 
-def _calendar_chain():
-    return [
-        {"expiry": "2025-01-01", "strike": 100, "type": "C", "bid": 1, "ask": 1.2, "delta": 0.4, "edge": 0.1, "iv": 0.2, "model": 1.5},
-        {"expiry": "2025-02-01", "strike": 100, "type": "C", "bid": 1, "ask": 1.1, "delta": 0.3, "edge": 0.1, "iv": 0.25, "model": 1.3},
-        {"expiry": "2025-03-01", "strike": 105, "type": "C", "bid": 1, "ask": 1.3, "delta": 0.2, "edge": 0.1, "iv": 0.3, "model": 1.4},
-    ]
-
-
-def _ratio_chain():
-    return [
-        {"expiry": "20250101", "strike": 110, "type": "C", "bid": 1.4, "ask": 1.6, "delta": 0.4, "edge": 0.2, "model": 1.7},
-        {"expiry": "20250101", "strike": 120, "type": "C", "bid": 0.3, "ask": 0.5, "delta": 0.25, "edge": 0.1, "model": 0.55},
-        {"expiry": "20250101", "strike": 130, "type": "C", "bid": 0.1, "ask": 0.2, "delta": 0.1, "edge": 0.05, "model": 0.22},
-    ]
-
-
-def test_calendar_field_compat(monkeypatch):
-    monkeypatch.setenv("TOMIC_TODAY", "2024-06-01")
-    chain = _calendar_chain()
-    old_cfg = {"calendar": {"strike_distance": [0], "expiry_gap_min": 20, "dte_range": [20, 80]}}
-    new_cfg = {"calendar": {"base_strikes_relative_to_spot": [0], "expiry_gap_min_days": 20, "dte_range": [20, 80]}}
-    rules_old = loader.load_strike_config("calendar", old_cfg)
-    rules_new = loader.load_strike_config("calendar", new_cfg)
-    cfg_old = {"strike_to_strategy_config": rules_old}
-    cfg_new = {"strike_to_strategy_config": rules_new}
-    props_old, _ = calendar.generate("AAA", chain, cfg_old, 100.0, 1.0)
-    props_new, _ = calendar.generate("AAA", chain, cfg_new, 100.0, 1.0)
-    assert props_old == props_new
-
-
-def test_ratio_spread_field_compat():
-    chain = _ratio_chain()
-    old_cfg = {"ratio_spread": {"short_delta_range": [0.3, 0.45], "long_leg_distance": [10], "use_ATR": False}}
-    new_cfg = {"ratio_spread": {"short_delta_range": [0.3, 0.45], "long_leg_distance_points": [10], "use_ATR": False}}
-    rules_old = loader.load_strike_config("ratio_spread", old_cfg)
-    rules_new = loader.load_strike_config("ratio_spread", new_cfg)
-    cfg_old = {"strike_to_strategy_config": rules_old}
-    cfg_new = {"strike_to_strategy_config": rules_new}
-    props_old, _ = ratio_spread.generate("AAA", chain, cfg_old, 100.0, 1.0)
-    props_new, _ = ratio_spread.generate("AAA", chain, cfg_new, 100.0, 1.0)
-    assert props_old == props_new
+@pytest.mark.parametrize("strategy,legacy,expected", [
+    (name, cfg[0], cfg[1]) for name, cfg in CASES.items()
+])
+def test_normalization(strategy, legacy, expected):
+    rules = loader.load_strike_config(strategy, {strategy: legacy})
+    assert rules == expected

--- a/tomic/strategies/atm_iron_butterfly.py
+++ b/tomic/strategies/atm_iron_butterfly.py
@@ -17,7 +17,6 @@ from ..strategy_candidates import (
     _find_option,
     _metrics,
 )
-from .config_normalizer import normalize_config
 
 
 def generate(
@@ -28,9 +27,6 @@ def generate(
     atr: float,
 ) -> tuple[List[StrategyProposal], list[str]]:
     rules = config.get("strike_to_strategy_config", {})
-    normalize_config(
-        rules, {"wing_width": ("wing_width_points", lambda v: v if isinstance(v, list) else [v])}
-    )
     use_atr = bool(rules.get("use_ATR"))
     if spot is None:
         raise ValueError("spot price is required")

--- a/tomic/strategies/backspread_put.py
+++ b/tomic/strategies/backspread_put.py
@@ -19,7 +19,6 @@ from ..strategy_candidates import (
     _validate_ratio,
     select_expiry_pairs,
 )
-from .config_normalizer import normalize_config
 
 
 def generate(
@@ -30,7 +29,6 @@ def generate(
     atr: float,
 ) -> tuple[List[StrategyProposal], list[str]]:
     rules = config.get("strike_to_strategy_config", {})
-    normalize_config(rules, {"short_delta_range": ("short_put_delta_range", None)})
     use_atr = bool(rules.get("use_ATR"))
     if spot is None:
         raise ValueError("spot price is required")

--- a/tomic/strategies/iron_condor.py
+++ b/tomic/strategies/iron_condor.py
@@ -19,7 +19,6 @@ from ..strategy_candidates import (
     _find_option,
     _metrics,
 )
-from .config_normalizer import normalize_config
 
 
 def generate(
@@ -30,9 +29,6 @@ def generate(
     atr: float,
 ) -> tuple[List[StrategyProposal], list[str]]:
     rules = config.get("strike_to_strategy_config", {})
-    normalize_config(
-        rules, {"wing_width": ("wing_width_points", lambda v: v if isinstance(v, list) else [v])}
-    )
     use_atr = bool(rules.get("use_ATR"))
     if spot is None:
         raise ValueError("spot price is required")

--- a/tomic/strategies/naked_put.py
+++ b/tomic/strategies/naked_put.py
@@ -13,7 +13,6 @@ from ..strategy_candidates import (
     _build_strike_map,
     _metrics,
 )
-from .config_normalizer import normalize_config
 
 
 def generate(
@@ -24,7 +23,6 @@ def generate(
     atr: float,
 ) -> tuple[List[StrategyProposal], list[str]]:
     rules = config.get("strike_to_strategy_config", {})
-    normalize_config(rules, {"short_delta_range": ("short_put_delta_range", None)})
     use_atr = bool(rules.get("use_ATR"))
     if spot is None:
         raise ValueError("spot price is required")

--- a/tomic/strategies/ratio_spread.py
+++ b/tomic/strategies/ratio_spread.py
@@ -18,7 +18,6 @@ from ..strategy_candidates import (
     _metrics,
     _validate_ratio,
 )
-from .config_normalizer import normalize_config
 
 
 def generate(
@@ -29,7 +28,6 @@ def generate(
     atr: float,
 ) -> tuple[List[StrategyProposal], list[str]]:
     rules = config.get("strike_to_strategy_config", {})
-    normalize_config(rules, {"short_delta_range": ("short_leg_delta_range", None)})
     use_atr = bool(rules.get("use_ATR"))
     if spot is None:
         raise ValueError("spot price is required")

--- a/tomic/strategies/short_call_spread.py
+++ b/tomic/strategies/short_call_spread.py
@@ -17,7 +17,6 @@ from ..strategy_candidates import (
     _find_option,
     _metrics,
 )
-from .config_normalizer import normalize_config
 
 
 def generate(
@@ -28,7 +27,6 @@ def generate(
     atr: float,
 ) -> tuple[List[StrategyProposal], list[str]]:
     rules = config.get("strike_to_strategy_config", {})
-    normalize_config(rules, {"short_delta_range": ("short_call_delta_range", None)})
     use_atr = bool(rules.get("use_ATR"))
     if spot is None:
         raise ValueError("spot price is required")

--- a/tomic/strategies/short_put_spread.py
+++ b/tomic/strategies/short_put_spread.py
@@ -17,7 +17,6 @@ from ..strategy_candidates import (
     _find_option,
     _metrics,
 )
-from .config_normalizer import normalize_config
 
 
 def generate(
@@ -28,7 +27,6 @@ def generate(
     atr: float,
 ) -> tuple[List[StrategyProposal], list[str]]:
     rules = config.get("strike_to_strategy_config", {})
-    normalize_config(rules, {"short_delta_range": ("short_put_delta_range", None)})
     use_atr = bool(rules.get("use_ATR"))
     if spot is None:
         raise ValueError("spot price is required")


### PR DESCRIPTION
## Summary
- Map all legacy strike rule keys in loader.normalize_strike_rule_fields with strategy-specific support
- Remove per-strategy normalize_config calls; strategies now expect pre-normalized configs
- Add consolidated tests verifying legacy key normalization across strategies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b481e01070832ea857680f42d6a564