### PR TITLE
Refactor strategy config for dynamic fields

### DIFF
--- a/config/strategies.yaml
+++ b/config/strategies.yaml
@@ -3,20 +3,18 @@ default:
   # (mag door iedere strategie overschreven worden)
   min_risk_reward: 1.0
   strike_to_strategy_config:
-    short_call_multiplier: [1.5, 2.0, 2.5, 3.0, 3.5]
-    short_put_multiplier:  [1.5, 2.0, 2.5, 3.0, 3.5]
-    wing_sigma_multiple: 1.0
-    long_leg_target_delta: 0.1
-    use_ATR: true
+    use_ATR: true                # standaard ATR-gebaseerde afstand
+    wing_width_sigma: 1.0        # wings standaard op ±1σ
+    long_leg_target_delta: 0.1   # long legs mikken op ±10Δ
 
 strategies:
   iron_condor:
     # TOMIC-beleid: minimaal 1.5
     min_risk_reward: 1.5
     strike_to_strategy_config:
-      short_call_multiplier: [1.5, 2.0, 2.5, 3.0, 3.5]
-      short_put_multiplier:  [1.5, 2.0, 2.5, 3.0, 3.5]
-      wing_sigma_multiple: 1.0
+      short_call_delta_range: [0.15, 0.30]   # verkochte calls 15–30Δ
+      short_put_delta_range: [-0.30, -0.15]  # verkochte puts 15–30Δ
+      wing_width_sigma: 1.0                  # wings op ±1σ van shorts
       use_ATR: true
 
   atm_iron_butterfly:
@@ -24,55 +22,47 @@ strategies:
     min_risk_reward: 1.0
     strike_to_strategy_config:
       # ATM short straddle + wings
-      short_call_multiplier: [1.0, 1.5, 2.0]
-      short_put_multiplier:  [1.0, 1.5, 2.0]
-      wing_sigma_multiple: 1.0
+      center_strike_relative_to_spot: [0]    # short straddle op spot
+      wing_width_sigma: 1.0                  # wings op ±1σ
       use_ATR: true
 
   short_put_spread:
     min_risk_reward: 1.0
     strike_to_strategy_config:
-      short_call_multiplier: [1.5, 2.0, 2.5]   # aanwezig voor uniformiteit (niet gebruikt)
-      short_put_multiplier:  [1.5, 2.0, 2.5, 3.0]
-      long_leg_target_delta: 0.1
+      short_put_delta_range: [-0.35, -0.20]  # short puts 20–35Δ
+      long_leg_target_delta: -0.05           # long leg mikken op -5Δ
       use_ATR: true
 
   short_call_spread:
     min_risk_reward: 1.0
     strike_to_strategy_config:
-      short_call_multiplier: [1.5, 2.0, 2.5, 3.0]
-      short_put_multiplier:  [1.5, 2.0, 2.5]   # aanwezig voor uniformiteit (niet gebruikt)
-      long_leg_target_delta: 0.1
+      short_call_delta_range: [0.15, 0.35]   # short calls 15–35Δ
+      long_leg_target_delta: 0.05            # long leg mikken op +5Δ
       use_ATR: true
 
   naked_put:
     # RR niet hard afdwingen; risico is theoretisch groot
     strike_to_strategy_config:
-      short_call_multiplier: [1.5, 2.0]        # aanwezig voor uniformiteit (niet gebruikt)
-      short_put_multiplier:  [1.0, 1.5, 2.0, 2.5]
+      short_put_delta_range: [-0.30, -0.20]  # short puts 20–30Δ
       use_ATR: true
 
   calendar:
     # Calendar focust minder op ATR-wings; long wings spelen niet
     strike_to_strategy_config:
-      short_call_multiplier: [1.0]              # niet van toepassing maar verplicht aanwezig
-      short_put_multiplier:  [1.0]
       use_ATR: false
-      base_strikes_relative_to_spot: [5]       # basis-strike op spot (0 ATR); kan worden uitgebreid
-      expiry_gap_min_days: 14
+      base_strikes_relative_to_spot: [0]     # basis-strike op spot
+      expiry_gap_min_days: 14               # minimaal 14 dagen tussen legs
 
   ratio_spread:
     # Vaak 1x2; RR afhankelijk van strikes, dus niet verplicht
     strike_to_strategy_config:
-      short_call_multiplier: [1.5, 2.0, 2.5]    # voor call-variant
-      short_put_multiplier:  [1.5, 2.0, 2.5]    # voor put-variant
-      long_leg_target_delta: 0.1
+      short_leg_delta_range: [0.25, 0.45]    # short leg 25–45Δ
+      long_leg_target_delta: 0.10           # extra long rond 10Δ
       use_ATR: true
 
   backspread_put:
     # Long vol; RR niet geforceerd
     strike_to_strategy_config:
-      short_call_multiplier: [1.5]              # aanwezig voor uniformiteit (niet gebruikt)
-      short_put_multiplier:  [1.5, 2.0, 2.5]
-      long_leg_target_delta: 0.1
+      short_put_delta_range: [0.10, 0.25]    # short puts 10–25Δ
+      long_leg_target_delta: -0.05           # long legs mikken op -5Δ
       use_ATR: true


### PR DESCRIPTION
## Summary
- remove outdated point-based fields in strategy config
- introduce delta- and sigma-based parameters per strategy with sensible defaults

## Testing
- `pytest -q`
- `pytest tests/analysis/test_strategy_modules.py::test_strategy_modules_smoke -q`


------
https://chatgpt.com/codex/tasks/task_b_68b493f9678c832ea9499d35f675c748