### PR TITLE
Replace multiplier strike config with delta ranges

### DIFF
--- a/tests/analysis/test_positive_credit.py
+++ b/tests/analysis/test_positive_credit.py
@@ -12,8 +12,8 @@ def test_iron_condor_negative_credit_rejected():
         "strategies": {
             "iron_condor": {
                 "strike_to_strategy_config": {
-                    "short_call_multiplier": [10],
-                    "short_put_multiplier": [10],
+                    "short_call_delta_range": [0.35, 0.45],
+                    "short_put_delta_range": [-0.35, -0.25],
                     "wing_sigma_multiple": 0.35,
                     "use_ATR": False,
                 }

--- a/tests/analysis/test_strategy_candidates_new.py
+++ b/tests/analysis/test_strategy_candidates_new.py
@@ -58,8 +58,8 @@ def test_generate_strategy_candidates_with_strings():
     ]
     cfg = {
         "strike_to_strategy_config": {
-            "short_call_multiplier": [10],
-            "short_put_multiplier": [10],
+            "short_call_delta_range": [0.35, 0.45],
+            "short_put_delta_range": [-0.35, -0.25],
             "wing_sigma_multiple": 1.0,
             "use_ATR": False,
         }
@@ -84,8 +84,8 @@ def test_generate_strategy_candidates_missing_metrics_reason():
     ]
     cfg = {
         "strike_to_strategy_config": {
-            "short_call_multiplier": [10],
-            "short_put_multiplier": [10],
+            "short_call_delta_range": [0.35, 0.45],
+            "short_put_delta_range": [-0.35, -0.25],
             "wing_sigma_multiple": 1.0,
             "use_ATR": False,
         }
@@ -150,8 +150,8 @@ def test_parity_mid_used_for_missing_bidask(monkeypatch):
     ]
     cfg = {
         "strike_to_strategy_config": {
-            "short_call_multiplier": [10],
-            "short_put_multiplier": [10],
+            "short_call_delta_range": [0.35, 0.45],
+            "short_put_delta_range": [-0.35, -0.25],
             "wing_sigma_multiple": 1.0,
             "use_ATR": False,
         }

--- a/tests/analysis/test_strategy_dynamic_config.py
+++ b/tests/analysis/test_strategy_dynamic_config.py
@@ -18,8 +18,8 @@ def test_generate_candidates_uses_global_config(monkeypatch):
             "strategies": {
                 "iron_condor": {
                     "strike_to_strategy_config": {
-                        "short_call_multiplier": [10],
-                        "short_put_multiplier": [10],
+                        "short_call_delta_range": [0.35, 0.45],
+                        "short_put_delta_range": [-0.35, -0.25],
                         "wing_sigma_multiple": 0.35,
                         "use_ATR": False,
                     }

--- a/tests/analysis/test_strike_rule_field_normalization.py
+++ b/tests/analysis/test_strike_rule_field_normalization.py
@@ -32,8 +32,16 @@ CASES = {
         {"wing_sigma_multiple": 5},
     ),
     "iron_condor": (
-        {"wing_width_points": [5]},
-        {"wing_sigma_multiple": 5},
+        {
+            "wing_width_points": [5],
+            "short_call_multiplier": [10],
+            "short_put_multiplier": [12],
+        },
+        {
+            "wing_sigma_multiple": 5,
+            "short_call_delta_range": [10],
+            "short_put_delta_range": [12],
+        },
     ),
 }
 

--- a/tomic/loader.py
+++ b/tomic/loader.py
@@ -26,6 +26,8 @@ def normalize_strike_rule_fields(
         "expiry_gap_min": "expiry_gap_min_days",
         "wing_width": "wing_width_points",
         "wing_width_points": "wing_width_sigma",
+        "short_call_multiplier": "short_call_delta_range",
+        "short_put_multiplier": "short_put_delta_range",
     }
     per_strategy: dict[str, dict[str, str]] = {
         "backspread_put": {"short_delta_range": "short_put_delta_range"},


### PR DESCRIPTION
## Summary
- normalize old `short_call_multiplier`/`short_put_multiplier` keys to `short_call_delta_range` and `short_put_delta_range`
- switch iron condor strategy to use delta range configuration for short legs
- update tests to drop multiplier fields and cover new normalization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b49a88b73c832e9da51a438dd1f565