### PR TITLE
Normalize strategy config and test legacy fields

### DIFF
--- a/tests/analysis/test_positive_credit.py
+++ b/tests/analysis/test_positive_credit.py
@@ -1,46 +1,103 @@
+from contextlib import nullcontext
+
+import pytest
+
 from tomic.strategy_candidates import generate_strategy_candidates
 
 
-def test_iron_condor_negative_credit_rejected():
+@pytest.mark.parametrize(
+    "cfg,expect_warn",
+    [
+        (
+            {
+                "strategies": {
+                    "iron_condor": {
+                        "strike_to_strategy_config": {
+                            "short_call_delta_range": [0.35, 0.45],
+                            "short_put_delta_range": [-0.35, -0.25],
+                            "wing_sigma_multiple": 0.35,
+                            "use_ATR": False,
+                        }
+                    }
+                }
+            },
+            False,
+        ),
+        (
+            {
+                "strategies": {
+                    "iron_condor": {
+                        "strike_config": {
+                            "short_call_multiplier": [0.35, 0.45],
+                            "short_put_multiplier": [-0.35, -0.25],
+                            "wing_width": 0.35,
+                            "use_ATR": False,
+                        }
+                    }
+                }
+            },
+            True,
+        ),
+    ],
+)
+def test_iron_condor_negative_credit_rejected(cfg, expect_warn):
     chain = [
         {"expiry": "20260101", "strike": 110, "type": "C", "bid": 1.0, "ask": 1.1, "delta": 0.4, "edge": 0.1, "iv": 0.2, "volume": 100, "open_interest": 1000},
         {"expiry": "20260101", "strike": 120, "type": "C", "bid": 2.9, "ask": 3.1, "delta": 0.2, "edge": 0.1, "iv": 0.2, "volume": 100, "open_interest": 1000},
         {"expiry": "20260101", "strike": 90, "type": "P", "bid": 1.0, "ask": 1.2, "delta": -0.3, "edge": 0.1, "iv": 0.2, "volume": 100, "open_interest": 1000},
         {"expiry": "20260101", "strike": 80, "type": "P", "bid": 2.8, "ask": 3.2, "delta": -0.1, "edge": 0.1, "iv": 0.2, "volume": 100, "open_interest": 1000},
     ]
-    cfg = {
-        "strategies": {
-            "iron_condor": {
-                "strike_to_strategy_config": {
-                    "short_call_delta_range": [0.35, 0.45],
-                    "short_put_delta_range": [-0.35, -0.25],
-                    "wing_sigma_multiple": 0.35,
-                    "use_ATR": False,
-                }
-            }
-        }
-    }
-    props, reasons = generate_strategy_candidates("AAA", "iron_condor", chain, 1.0, config=cfg, spot=100.0)
+    ctx = pytest.warns(DeprecationWarning) if expect_warn else nullcontext()
+    with ctx:
+        props, reasons = generate_strategy_candidates(
+            "AAA", "iron_condor", chain, 1.0, config=cfg, spot=100.0
+        )
     assert not props
     assert "ontbrekende strikes" in reasons
 
 
-def test_short_call_spread_negative_credit_rejected():
+@pytest.mark.parametrize(
+    "cfg,expect_warn",
+    [
+        (
+            {
+                "strategies": {
+                    "short_call_spread": {
+                        "strike_to_strategy_config": {
+                            "short_call_delta_range": [0.35, 0.45],
+                            "long_leg_target_delta": 0.1,
+                            "use_ATR": False,
+                        }
+                    }
+                }
+            },
+            False,
+        ),
+        (
+            {
+                "strategies": {
+                    "short_call_spread": {
+                        "strike_config": {
+                            "short_delta_range": [0.35, 0.45],
+                            "long_leg_distance_points": 0.1,
+                            "use_ATR": False,
+                        }
+                    }
+                }
+            },
+            True,
+        ),
+    ],
+)
+def test_short_call_spread_negative_credit_rejected(cfg, expect_warn):
     chain = [
         {"expiry": "20260101", "strike": 110, "type": "C", "bid": 1.0, "ask": 1.1, "delta": 0.4, "edge": 0.1, "iv": 0.2, "volume": 100, "open_interest": 1000},
         {"expiry": "20260101", "strike": 120, "type": "C", "bid": 2.9, "ask": 3.1, "delta": 0.2, "edge": 0.1, "iv": 0.2, "volume": 100, "open_interest": 1000},
     ]
-    cfg = {
-        "strategies": {
-            "short_call_spread": {
-                "strike_to_strategy_config": {
-                    "short_call_delta_range": [0.35, 0.45],
-                    "long_leg_target_delta": 0.1,
-                    "use_ATR": False,
-                }
-            }
-        }
-    }
-    props, reasons = generate_strategy_candidates("AAA", "short_call_spread", chain, 1.0, config=cfg, spot=100.0)
+    ctx = pytest.warns(DeprecationWarning) if expect_warn else nullcontext()
+    with ctx:
+        props, reasons = generate_strategy_candidates(
+            "AAA", "short_call_spread", chain, 1.0, config=cfg, spot=100.0
+        )
     assert not props
     assert "negatieve credit" in reasons

--- a/tomic/strategy_candidates.py
+++ b/tomic/strategy_candidates.py
@@ -30,6 +30,8 @@ from .logutils import logger, log_combo_evaluation
 from .criteria import CriteriaConfig, RULES, load_criteria
 from .strategies import StrategyName
 from .config import get as cfg_get
+from .loader import normalize_strike_rule_fields
+from .strategies.config_normalizer import normalize_config
 
 
 # Strategies that must yield a positive net credit are configured via RULES.
@@ -589,6 +591,10 @@ def generate_strategy_candidates(
     cfg_data = config if config is not None else cfg_get("STRATEGY_CONFIG", {})
     base = cfg_data.get("default", {})
     strat_cfg = {**base, **cfg_data.get("strategies", {}).get(strategy_type, {})}
+    normalize_config(strat_cfg, {"strike_config": ("strike_to_strategy_config", None)})
+    strat_cfg["strike_to_strategy_config"] = normalize_strike_rule_fields(
+        strat_cfg.get("strike_to_strategy_config", {}), strategy_type
+    )
     result = mod.generate(symbol, option_chain, strat_cfg, spot, atr)
     if isinstance(result, tuple):
         proposals, reasons = result


### PR DESCRIPTION
## Summary
- normalize strategy configuration in generate_strategy_candidates
- add tests covering both new and legacy config fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b4a243134c832e946a653b0fa2f022