### PR TITLE
Validate strategy names and default risk/reward

### DIFF
--- a/tests/analysis/test_strategy_rules_loader.py
+++ b/tests/analysis/test_strategy_rules_loader.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from tomic.criteria import StrategyRules
+from tomic.criteria import StrategyRules, StrategyAcceptanceRules
 
 
 def test_strategy_score_weights_must_sum_to_one():
@@ -11,3 +11,8 @@ def test_strategy_score_weights_must_sum_to_one():
             score_weight_pos=0.3,
             score_weight_ev=0.2,
         )
+
+
+def test_acceptance_rejects_unknown_names():
+    with pytest.raises(ValidationError):
+        StrategyAcceptanceRules(require_positive_credit_for=["not_a_strategy"])

--- a/tomic/criteria.py
+++ b/tomic/criteria.py
@@ -15,7 +15,9 @@ from pathlib import Path
 import math
 from typing import List
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, model_validator, field_validator
+
+from .strategies import StrategyName
 
 from .config import _load_yaml  # reuse YAML loader
 
@@ -42,6 +44,18 @@ class StrategyAcceptanceRules(BaseModel):
     """Rules governing which strategies are acceptable."""
 
     require_positive_credit_for: List[str] = []
+    min_risk_reward: float | None = None
+
+    @field_validator("require_positive_credit_for")
+    @classmethod
+    def _validate_names(cls, v: List[str]) -> List[str]:
+        valid = {s.value for s in StrategyName}
+        invalid = [name for name in v if name not in valid]
+        if invalid:
+            raise ValueError(
+                "unknown strategy names: " + ", ".join(invalid)
+            )
+        return v
 
 
 class StrategyRules(BaseModel):

--- a/tomic/strategy_candidates.py
+++ b/tomic/strategy_candidates.py
@@ -592,6 +592,8 @@ def generate_strategy_candidates(
     base = cfg_data.get("default", {})
     strat_cfg = {**base, **cfg_data.get("strategies", {}).get(strategy_type, {})}
     normalize_config(strat_cfg, {"strike_config": ("strike_to_strategy_config", None)})
+    if "min_risk_reward" not in strat_cfg or strat_cfg["min_risk_reward"] is None:
+        strat_cfg["min_risk_reward"] = RULES.strategy.acceptance.min_risk_reward
     strat_cfg["strike_to_strategy_config"] = normalize_strike_rule_fields(
         strat_cfg.get("strike_to_strategy_config", {}), strategy_type
     )


### PR DESCRIPTION
## Summary
- add `min_risk_reward` to `StrategyAcceptanceRules`
- validate `require_positive_credit_for` entries against `StrategyName`
- default strategy min risk/reward from acceptance rules

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b544db7bf4832e8961abf28ec4d0f5