### PR TITLE
feat: unify long leg distance naming

### DIFF
--- a/config/strategies.yaml
+++ b/config/strategies.yaml
@@ -5,7 +5,7 @@ default:
   strike_to_strategy_config:
     use_ATR: true                # standaard ATR-gebaseerde afstand
     wing_width_sigma: 1.0        # wings standaard op ±1σ
-    long_leg_target_delta: 0.1   # long legs mikken op ±10Δ
+    long_leg_distance_points: 0.1   # long legs mikken op ±10Δ
 
 strategies:
   iron_condor:
@@ -30,14 +30,14 @@ strategies:
     min_risk_reward: 1.0
     strike_to_strategy_config:
       short_put_delta_range: [-0.35, -0.20]  # short puts 20–35Δ
-      long_leg_target_delta: -0.05           # long leg mikken op -5Δ
+      long_leg_distance_points: -0.05        # long leg mikken op -5Δ
       use_ATR: true
 
   short_call_spread:
     min_risk_reward: 1.0
     strike_to_strategy_config:
       short_call_delta_range: [0.15, 0.35]   # short calls 15–35Δ
-      long_leg_target_delta: 0.05            # long leg mikken op +5Δ
+      long_leg_distance_points: 0.05         # long leg mikken op +5Δ
       use_ATR: true
 
   naked_put:
@@ -57,12 +57,12 @@ strategies:
     # Vaak 1x2; RR afhankelijk van strikes, dus niet verplicht
     strike_to_strategy_config:
       short_leg_delta_range: [0.25, 0.45]    # short leg 25–45Δ
-      long_leg_target_delta: 0.10           # extra long rond 10Δ
+      long_leg_distance_points: 0.10        # extra long rond 10Δ
       use_ATR: true
 
   backspread_put:
     # Long vol; RR niet geforceerd
     strike_to_strategy_config:
       short_put_delta_range: [0.10, 0.25]    # short puts 10–25Δ
-      long_leg_target_delta: -0.05           # long legs mikken op -5Δ
+      long_leg_distance_points: -0.05        # long legs mikken op -5Δ
       use_ATR: true

--- a/tests/analysis/test_positive_credit.py
+++ b/tests/analysis/test_positive_credit.py
@@ -65,7 +65,7 @@ def test_iron_condor_negative_credit_rejected(cfg, expect_warn):
                     "short_call_spread": {
                         "strike_to_strategy_config": {
                             "short_call_delta_range": [0.35, 0.45],
-                            "long_leg_target_delta": 0.1,
+                            "long_leg_distance_points": 0.1,
                             "use_ATR": False,
                         }
                     }
@@ -79,7 +79,7 @@ def test_iron_condor_negative_credit_rejected(cfg, expect_warn):
                     "short_call_spread": {
                         "strike_config": {
                             "short_delta_range": [0.35, 0.45],
-                            "long_leg_distance_points": 0.1,
+                            "long_call_distance_points": 0.1,
                             "use_ATR": False,
                         }
                     }

--- a/tests/analysis/test_strategy_modules.py
+++ b/tests/analysis/test_strategy_modules.py
@@ -14,19 +14,19 @@ strategies = [
     ),
     (
         StrategyName.SHORT_PUT_SPREAD,
-        {"strike_to_strategy_config": {"short_put_delta_range": [-0.35, -0.2], "long_leg_target_delta": 0.1, "use_ATR": False}},
+        {"strike_to_strategy_config": {"short_put_delta_range": [-0.35, -0.2], "long_leg_distance_points": 0.1, "use_ATR": False}},
     ),
     (
         StrategyName.SHORT_CALL_SPREAD,
-        {"strike_to_strategy_config": {"short_call_delta_range": [0.2, 0.35], "long_leg_target_delta": 0.1, "use_ATR": False}},
+        {"strike_to_strategy_config": {"short_call_delta_range": [0.2, 0.35], "long_leg_distance_points": 0.1, "use_ATR": False}},
     ),
     (
         StrategyName.RATIO_SPREAD,
-        {"strike_to_strategy_config": {"short_leg_delta_range": [0.3, 0.45], "long_leg_target_delta": 0.1, "use_ATR": False}},
+        {"strike_to_strategy_config": {"short_leg_delta_range": [0.3, 0.45], "long_leg_distance_points": 0.1, "use_ATR": False}},
     ),
     (
         StrategyName.BACKSPREAD_PUT,
-        {"strike_to_strategy_config": {"short_put_delta_range": [0.15, 0.3], "long_leg_target_delta": 0.1, "use_ATR": False}},
+        {"strike_to_strategy_config": {"short_put_delta_range": [0.15, 0.3], "long_leg_distance_points": 0.1, "use_ATR": False}},
     ),
     (
         StrategyName.ATM_IRON_BUTTERFLY,
@@ -41,19 +41,19 @@ legacy_strategies = [
     ),
     (
         StrategyName.SHORT_PUT_SPREAD,
-        {"short_delta_range": [-0.35, -0.2], "long_leg_distance_points": 5, "use_ATR": False},
+        {"short_delta_range": [-0.35, -0.2], "long_put_distance_points": 5, "use_ATR": False},
     ),
     (
         StrategyName.SHORT_CALL_SPREAD,
-        {"short_delta_range": [0.2, 0.35], "long_leg_distance_points": 5, "use_ATR": False},
+        {"short_delta_range": [0.2, 0.35], "long_call_distance_points": 5, "use_ATR": False},
     ),
     (
         StrategyName.RATIO_SPREAD,
-        {"short_delta_range": [0.3, 0.45], "long_leg_distance_points": 5, "use_ATR": False},
+        {"short_delta_range": [0.3, 0.45], "long_leg_target_delta": 5, "use_ATR": False},
     ),
     (
         StrategyName.BACKSPREAD_PUT,
-        {"short_delta_range": [0.15, 0.3], "long_leg_distance_points": 5, "use_ATR": False},
+        {"short_delta_range": [0.15, 0.3], "long_put_distance_points": 5, "use_ATR": False},
     ),
     (
         StrategyName.ATM_IRON_BUTTERFLY,

--- a/tests/analysis/test_strike_rule_field_normalization.py
+++ b/tests/analysis/test_strike_rule_field_normalization.py
@@ -16,16 +16,16 @@ CASES = {
         {"short_put_delta_range": [-0.3, -0.25]},
     ),
     "short_put_spread": (
-        {"short_delta_range": [-0.35, -0.2], "long_leg_distance_points": 5},
-        {"short_put_delta_range": [-0.35, -0.2], "long_leg_target_delta": 5},
+        {"short_delta_range": [-0.35, -0.2], "long_put_distance_points": 5},
+        {"short_put_delta_range": [-0.35, -0.2], "long_leg_distance_points": 5},
     ),
     "backspread_put": (
-        {"short_delta_range": [0.15, 0.3], "long_leg_distance_points": 5},
-        {"short_put_delta_range": [0.15, 0.3], "long_leg_target_delta": 5},
+        {"short_delta_range": [0.15, 0.3], "long_put_distance_points": 5},
+        {"short_put_delta_range": [0.15, 0.3], "long_leg_distance_points": 5},
     ),
     "short_call_spread": (
-        {"short_delta_range": [0.2, 0.35], "long_leg_distance_points": 5},
-        {"short_call_delta_range": [0.2, 0.35], "long_leg_target_delta": 5},
+        {"short_delta_range": [0.2, 0.35], "long_call_distance_points": 5},
+        {"short_call_delta_range": [0.2, 0.35], "long_leg_distance_points": 5},
     ),
     "atm_iron_butterfly": (
         {"wing_width": 5},

--- a/tomic/loader.py
+++ b/tomic/loader.py
@@ -21,7 +21,9 @@ def normalize_strike_rule_fields(
 
     mapping: dict[str, str] = {
         "long_leg_distance": "long_leg_distance_points",
-        "long_leg_distance_points": "long_leg_target_delta",
+        "long_leg_target_delta": "long_leg_distance_points",
+        "long_put_distance_points": "long_leg_distance_points",
+        "long_call_distance_points": "long_leg_distance_points",
         "strike_distance": "base_strikes_relative_to_spot",
         "expiry_gap_min": "expiry_gap_min_days",
         "wing_width": "wing_width_points",

--- a/tomic/strategies/backspread_put.py
+++ b/tomic/strategies/backspread_put.py
@@ -128,7 +128,7 @@ def generate(
         return rr >= min_rr
 
     delta_range = rules.get("short_put_delta_range") or []
-    target_delta = rules.get("long_leg_target_delta")
+    target_delta = rules.get("long_leg_distance_points")
     atr_mult = rules.get("long_leg_atr_multiple")
     min_gap = int(rules.get("expiry_gap_min_days", 0))
     pairs = select_expiry_pairs(expiries, min_gap)

--- a/tomic/strategies/ratio_spread.py
+++ b/tomic/strategies/ratio_spread.py
@@ -126,7 +126,7 @@ def generate(
         return rr >= min_rr
 
     delta_range = rules.get("short_leg_delta_range") or []
-    target_delta = rules.get("long_leg_target_delta")
+    target_delta = rules.get("long_leg_distance_points")
     atr_mult = rules.get("long_leg_atr_multiple")
     if len(delta_range) == 2 and (target_delta is not None or atr_mult is not None):
         calls_pre = []

--- a/tomic/strategies/short_call_spread.py
+++ b/tomic/strategies/short_call_spread.py
@@ -127,7 +127,7 @@ def generate(
         return rr >= min_rr
 
     delta_range = rules.get("short_call_delta_range") or []
-    target_delta = rules.get("long_leg_target_delta")
+    target_delta = rules.get("long_leg_distance_points")
     atr_mult = rules.get("long_leg_atr_multiple")
     if len(delta_range) == 2 and (target_delta is not None or atr_mult is not None):
         short_opt = None

--- a/tomic/strategies/short_put_spread.py
+++ b/tomic/strategies/short_put_spread.py
@@ -127,7 +127,7 @@ def generate(
         return rr >= min_rr
 
     delta_range = rules.get("short_put_delta_range") or []
-    target_delta = rules.get("long_leg_target_delta")
+    target_delta = rules.get("long_leg_distance_points")
     atr_mult = rules.get("long_leg_atr_multiple")
     if len(delta_range) == 2 and (target_delta is not None or atr_mult is not None):
         short_opt = None

--- a/tomic/strike_selection_rules.yaml
+++ b/tomic/strike_selection_rules.yaml
@@ -38,7 +38,7 @@ short_put_spread:
   #iv_rank_min: 0.50                   # align met vol-rules (hogere IV vereist)
   #max_skew: 0.25
   min_risk_reward: 1.0
-  long_leg_target_delta: -0.05      # mik op long leg rond -5Δ
+  long_leg_distance_points: -0.05      # mik op long leg rond -5Δ
 
 short_call_spread:
   method: delta
@@ -48,7 +48,7 @@ short_call_spread:
   #iv_rank_min: 0.50                   # align met vol-rules
   #max_skew: 0.25
   min_risk_reward: 0.6
-  long_leg_target_delta: 0.05       # mik op long leg rond +5Δ
+  long_leg_distance_points: 0.05       # mik op long leg rond +5Δ
 
 naked_put:
   method: delta


### PR DESCRIPTION
## Summary
- adopt `long_leg_distance_points` as canonical strike rule
- map deprecated `long_put_distance_points` and `long_call_distance_points` to the new field
- update strategy configs, modules and tests to new naming

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b555494864832eb82fae85a72d066e