### PR TITLE
Validate strategy configs

### DIFF
--- a/tests/analysis/test_strategy_config_validation.py
+++ b/tests/analysis/test_strategy_config_validation.py
@@ -1,0 +1,21 @@
+import pytest
+from pydantic import ValidationError
+
+from tomic.strategy_candidates import generate_strategy_candidates
+
+
+@pytest.mark.parametrize(
+    "strategy,cfg",
+    [
+        ("naked_put", {"strike_to_strategy_config": {"unknown": 1}}),
+        (
+            "short_put_spread",
+            {"strike_to_strategy_config": {"short_put_delta_range": "oops"}},
+        ),
+    ],
+)
+def test_invalid_strike_config(strategy, cfg, monkeypatch):
+    """Config models should reject invalid fields or types."""
+    monkeypatch.setenv("TOMIC_TODAY", "2024-06-01")
+    with pytest.raises(ValidationError):
+        generate_strategy_candidates("AAA", strategy, [], 1.0, cfg, 100.0)

--- a/tomic/strategies/config_models.py
+++ b/tomic/strategies/config_models.py
@@ -1,0 +1,114 @@
+"""Pydantic models for strategy configurations."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from pydantic import BaseModel, ConfigDict
+
+
+class _BaseStrikeConfig(BaseModel):
+    """Common fields shared by multiple strategies."""
+
+    use_ATR: bool | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class _BaseConfig(BaseModel):
+    """Top-level strategy config wrapper."""
+
+    min_risk_reward: float | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ShortPutSpreadStrikeConfig(_BaseStrikeConfig):
+    short_put_delta_range: Tuple[float, float]
+    long_leg_distance_points: float | None = None
+    long_leg_atr_multiple: float | None = None
+
+
+class ShortPutSpreadConfig(_BaseConfig):
+    strike_to_strategy_config: ShortPutSpreadStrikeConfig
+
+
+class ShortCallSpreadStrikeConfig(_BaseStrikeConfig):
+    short_call_delta_range: Tuple[float, float]
+    long_leg_distance_points: float | None = None
+    long_leg_atr_multiple: float | None = None
+
+
+class ShortCallSpreadConfig(_BaseConfig):
+    strike_to_strategy_config: ShortCallSpreadStrikeConfig
+
+
+class NakedPutStrikeConfig(_BaseStrikeConfig):
+    short_put_delta_range: Tuple[float, float]
+
+
+class NakedPutConfig(_BaseConfig):
+    strike_to_strategy_config: NakedPutStrikeConfig
+
+
+class CalendarStrikeConfig(_BaseStrikeConfig):
+    base_strikes_relative_to_spot: List[float]
+    expiry_gap_min_days: int
+
+
+class CalendarConfig(_BaseConfig):
+    strike_to_strategy_config: CalendarStrikeConfig
+
+
+class IronCondorStrikeConfig(_BaseStrikeConfig):
+    short_call_delta_range: Tuple[float, float]
+    short_put_delta_range: Tuple[float, float]
+    wing_sigma_multiple: float | None = None
+
+
+class IronCondorConfig(_BaseConfig):
+    strike_to_strategy_config: IronCondorStrikeConfig
+
+
+class AtmIronButterflyStrikeConfig(_BaseStrikeConfig):
+    center_strike_relative_to_spot: List[float]
+    wing_sigma_multiple: float | None = None
+
+
+class AtmIronButterflyConfig(_BaseConfig):
+    strike_to_strategy_config: AtmIronButterflyStrikeConfig
+
+
+class RatioSpreadStrikeConfig(_BaseStrikeConfig):
+    short_leg_delta_range: Tuple[float, float]
+    long_leg_distance_points: float | None = None
+    long_leg_atr_multiple: float | None = None
+
+
+class RatioSpreadConfig(_BaseConfig):
+    strike_to_strategy_config: RatioSpreadStrikeConfig
+
+
+class BackspreadPutStrikeConfig(_BaseStrikeConfig):
+    short_put_delta_range: Tuple[float, float]
+    long_leg_distance_points: float | None = None
+    long_leg_atr_multiple: float | None = None
+    expiry_gap_min_days: int | None = None
+
+
+class BackspreadPutConfig(_BaseConfig):
+    strike_to_strategy_config: BackspreadPutStrikeConfig
+
+
+CONFIG_MODELS = {
+    "short_put_spread": ShortPutSpreadConfig,
+    "short_call_spread": ShortCallSpreadConfig,
+    "naked_put": NakedPutConfig,
+    "calendar": CalendarConfig,
+    "iron_condor": IronCondorConfig,
+    "atm_iron_butterfly": AtmIronButterflyConfig,
+    "ratio_spread": RatioSpreadConfig,
+    "backspread_put": BackspreadPutConfig,
+}
+
+__all__ = ["CONFIG_MODELS"]

--- a/tomic/strategy_candidates.py
+++ b/tomic/strategy_candidates.py
@@ -32,6 +32,8 @@ from .strategies import StrategyName
 from .config import get as cfg_get
 from .loader import normalize_strike_rule_fields
 from .strategies.config_normalizer import normalize_config
+from .strategies.config_models import CONFIG_MODELS
+from .config import _asdict
 
 
 # Strategies that must yield a positive net credit are configured via RULES.
@@ -597,6 +599,9 @@ def generate_strategy_candidates(
     strat_cfg["strike_to_strategy_config"] = normalize_strike_rule_fields(
         strat_cfg.get("strike_to_strategy_config", {}), strategy_type
     )
+    model_cls = CONFIG_MODELS.get(strategy_type)
+    if model_cls is not None:
+        strat_cfg = _asdict(model_cls(**strat_cfg))
     result = mod.generate(symbol, option_chain, strat_cfg, spot, atr)
     if isinstance(result, tuple):
         proposals, reasons = result


### PR DESCRIPTION
## Summary
- define Pydantic Config models for each strategy to validate `strike_to_strategy_config`
- hook Config models into `generate_strategy_candidates`
- add tests ensuring invalid fields or types raise validation errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b5973ae38c832e8a2fd3428f60e0a5