### PR TITLE
Handle iron condor across multiple expiries

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Geen automatische trading – TOMIC ondersteunt, jij beslist.
 Feature	Beschrijving
 📡 Marktdata ophalen	Spotprijs, IV-metrics, skew en option chains per symbool
 📊 Portfolio-analyse	Gebaseerd op je huidige posities en Greeks
-🎯 Strategie-selectie	Maximaal 5 kansen volgens TOMIC-score
+🎯 Strategie-selectie	Maximaal 5 kansen volgens TOMIC-score over meerdere expiraties binnen DTE-bereik
 ✍️ Journal-integratie	Met exit-signalen, EV, PoS, risico en entrylogica
 📁 Exporteerbaar	CSV/JSON-export voor eigen dashboards of analyse
 📲 Theoretical value calculator  Bereken optiewaarde en edge t.o.v. midprice


### PR DESCRIPTION
## Summary
- Generate iron condor proposals for every expiry within configured DTE range
- Aggregate and sort proposals across expiries
- Document and test multi-expiry candidate generation

## Testing
- `pytest tests/analysis/test_strategy_candidates_new.py tests/analysis/test_strategy_dynamic_config.py tests/analysis/test_positive_credit.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68b5de779f4c832eb5e0b5367f5b70f5