### PR TITLE
Include leg details in strategy evaluation logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ exporteren.
 Exports worden geplaatst onder `exports/tradecandidates/YYYYMMDD/` met de naam
 `trade_candidates_<symbol>_<strategy>_<expiry>_<HHMMSS>.csv`.
 
+Elke strategie-evaluatie logt nu ook de gebruikte legs. De logregel toont de
+expiratie en per leg het type en de strike, bijvoorbeeld
+`expiry=2025-01-01 | SC=110C | LC=120C | SP=90P | LP=80P`. Deze volgorde komt
+overeen met de rijen in het bijbehorende `trade_candidates_*.csv`-bestand,
+zodat je eenvoudig kunt terugvinden welke combinatie tot een bepaald logresultaat
+leidde.
+
 Krijg je geen voorstellen, dan toont TOMIC nu ook hoeveel combinaties zijn
 afgewezen door een ratioscheck of risicocriteria. Zo weet je direct waarom er
 geen strategie werd gevonden.

--- a/tests/analysis/test_short_call_spread_logging.py
+++ b/tests/analysis/test_short_call_spread_logging.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+from tomic.strategies import short_call_spread
+from tomic import logutils
+
+
+def _chain():
+    return [
+        {
+            "expiry": "2025-01-01",
+            "strike": 90,
+            "type": "P",
+            "bid": 1.0,
+            "ask": 1.1,
+            "delta": -0.3,
+            "edge": 0.1,
+            "model": 0.1,
+            "iv": 0.2,
+        }
+    ]
+
+
+def test_short_call_spread_expiry_logging(monkeypatch):
+    monkeypatch.setenv("TOMIC_TODAY", "2024-06-01")
+    cfg = {
+        "strike_to_strategy_config": {
+            "short_call_delta_range": [0.35, 0.45],
+            "long_leg_distance_points": 5,
+        }
+    }
+    messages: list[str] = []
+    monkeypatch.setattr(logutils, "logger", SimpleNamespace(info=lambda m: messages.append(m)))
+    short_call_spread.generate("AAA", _chain(), cfg, 100.0, 1.0)
+    assert any("short optie ontbreekt" in m and "expiry=2025-01-01" in m for m in messages)

--- a/tomic/strategies/atm_iron_butterfly.py
+++ b/tomic/strategies/atm_iron_butterfly.py
@@ -61,6 +61,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=[{"expiry": expiry}],
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -74,6 +75,8 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=[{"expiry": expiry, "strike": center, "type": "C", "position": -1},
+                          {"expiry": expiry, "strike": center, "type": "P", "position": -1}],
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -86,6 +89,8 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=[{"expiry": expiry, "strike": center, "type": "C", "position": -1},
+                          {"expiry": expiry, "strike": center, "type": "P", "position": -1}],
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -94,6 +99,12 @@ def generate(
             lc_strike = _nearest_strike(strike_map, expiry, "C", center + width).matched
             lp_strike = _nearest_strike(strike_map, expiry, "P", center - width).matched
             desc = f"center {center} sigma {sigma_mult}"  # width implied
+            base_legs = [
+                {"expiry": expiry, "strike": sc_strike, "type": "C", "position": -1},
+                {"expiry": expiry, "strike": sp_strike, "type": "P", "position": -1},
+                {"expiry": expiry, "strike": lc_strike, "type": "C", "position": 1},
+                {"expiry": expiry, "strike": lp_strike, "type": "P", "position": 1},
+            ]
             if not all([sc_strike, sp_strike, lc_strike, lp_strike]):
                 reason = "ontbrekende strikes"
                 log_combo_evaluation(
@@ -102,6 +113,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=base_legs,
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -115,6 +127,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=base_legs,
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -132,6 +145,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=base_legs,
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -144,6 +158,7 @@ def generate(
                     metrics,
                     "pass",
                     "criteria",
+                    legs=legs,
                 )
             else:
                 reason = "; ".join(reasons) if reasons else "risk/reward onvoldoende"
@@ -153,6 +168,7 @@ def generate(
                     metrics,
                     "reject",
                     reason,
+                    legs=legs,
                 )
                 if reasons:
                     rejected_reasons.extend(reasons)

--- a/tomic/strategies/backspread_put.py
+++ b/tomic/strategies/backspread_put.py
@@ -81,6 +81,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=[{"expiry": near}],
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -107,6 +108,9 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=[
+                        {"expiry": near, "strike": short_opt.get("strike"), "type": "P", "position": -1}
+                    ],
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -115,6 +119,10 @@ def generate(
             desc = (
                 f"near {near} far {far} short {short_opt.get('strike')} long {long_strike.matched}"
             )
+            legs_info = [
+                {"expiry": near, "strike": short_opt.get("strike"), "type": "P", "position": -1},
+                {"expiry": far, "strike": long_strike.matched, "type": "P", "position": 2},
+            ]
             if not long_strike.matched:
                 reason = "long strike niet gevonden"
                 log_combo_evaluation(
@@ -123,6 +131,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=legs_info,
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -135,6 +144,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=legs_info,
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -150,6 +160,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=legs_info,
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -163,6 +174,7 @@ def generate(
                         metrics,
                         "pass",
                         "criteria",
+                        legs=legs,
                     )
                 else:
                     reason = "verkeerde ratio"
@@ -172,6 +184,7 @@ def generate(
                         metrics,
                         "reject",
                         reason,
+                        legs=legs,
                     )
                     rejected_reasons.append(reason)
             else:
@@ -182,6 +195,7 @@ def generate(
                     metrics,
                     "reject",
                     reason,
+                    legs=legs,
                 )
                 if reasons:
                     rejected_reasons.extend(reasons)

--- a/tomic/strategies/calendar.py
+++ b/tomic/strategies/calendar.py
@@ -106,10 +106,14 @@ def generate(
                 short_opt = by_strike[nearest].get(near)
                 long_opt = by_strike[nearest].get(far)
                 desc = f"{option_type} strike {nearest} near {near} far {far}"
+                legs_info = [
+                    {"expiry": near, "strike": nearest, "type": option_type, "position": -1},
+                    {"expiry": far, "strike": nearest, "type": option_type, "position": 1},
+                ]
                 if not short_opt or not long_opt:
                     reason = "opties niet gevonden"
                     log_combo_evaluation(
-                        StrategyName.CALENDAR, desc, None, "reject", reason
+                        StrategyName.CALENDAR, desc, None, "reject", reason, legs=legs_info
                     )
                     local_reasons.append(reason)
                     continue
@@ -120,7 +124,7 @@ def generate(
                 if any(l is None for l in legs):
                     reason = "leg data ontbreekt"
                     log_combo_evaluation(
-                        StrategyName.CALENDAR, desc, None, "reject", reason
+                        StrategyName.CALENDAR, desc, None, "reject", reason, legs=legs_info
                     )
                     local_reasons.append(reason)
                     continue
@@ -128,7 +132,7 @@ def generate(
                 if not metrics:
                     reason = "; ".join(reasons) if reasons else "metrics niet berekend"
                     log_combo_evaluation(
-                        StrategyName.CALENDAR, desc, metrics, "reject", reason
+                        StrategyName.CALENDAR, desc, metrics, "reject", reason, legs=legs
                     )
                     if reasons:
                         local_reasons.extend(reasons)
@@ -140,13 +144,13 @@ def generate(
                 if not passes_risk(metrics, min_rr):
                     reason = "risk/reward onvoldoende"
                     log_combo_evaluation(
-                        StrategyName.CALENDAR, desc, metrics, "reject", reason
+                        StrategyName.CALENDAR, desc, metrics, "reject", reason, legs=legs
                     )
                     local_reasons.append(reason)
                     continue
                 local_props.append(StrategyProposal(legs=legs, **metrics))
                 log_combo_evaluation(
-                    StrategyName.CALENDAR, desc, metrics, "pass", "criteria"
+                    StrategyName.CALENDAR, desc, metrics, "pass", "criteria", legs=legs
                 )
                 if len(local_props) >= 5:
                     break

--- a/tomic/strategies/naked_put.py
+++ b/tomic/strategies/naked_put.py
@@ -62,6 +62,14 @@ def generate(
                             None,
                             "reject",
                             reason,
+                            legs=[
+                                {
+                                    "expiry": expiry,
+                                    "strike": opt.get("strike"),
+                                    "type": opt.get("type") or opt.get("right"),
+                                    "position": -1,
+                                }
+                            ],
                         )
                         rejected_reasons.append(reason)
                         continue
@@ -74,6 +82,7 @@ def generate(
                             metrics,
                             "pass",
                             "criteria",
+                            legs=[leg],
                         )
                     else:
                         reason = "; ".join(reasons) if reasons else "risk/reward onvoldoende"
@@ -83,6 +92,7 @@ def generate(
                             metrics,
                             "reject",
                             reason,
+                            legs=[leg],
                         )
                         if reasons:
                             rejected_reasons.extend(reasons)

--- a/tomic/strategies/ratio_spread.py
+++ b/tomic/strategies/ratio_spread.py
@@ -98,6 +98,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=[{"expiry": expiry}],
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -122,12 +123,19 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=[
+                        {"expiry": expiry, "strike": short_opt.get("strike"), "type": "C", "position": -1}
+                    ],
                 )
                 rejected_reasons.append(reason)
                 continue
             long_strike_target = float(short_opt.get("strike")) + width
             long_strike = _nearest_strike(strike_map, expiry, "C", long_strike_target)
             desc = f"short {short_opt.get('strike')} long {long_strike.matched}"
+            legs_info = [
+                {"expiry": expiry, "strike": short_opt.get("strike"), "type": "C", "position": -1},
+                {"expiry": expiry, "strike": long_strike.matched, "type": "C", "position": 2},
+            ]
             if not long_strike.matched:
                 reason = "long strike niet gevonden"
                 log_combo_evaluation(
@@ -136,6 +144,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=legs_info,
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -148,6 +157,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=legs_info,
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -163,6 +173,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=legs_info,
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -178,6 +189,7 @@ def generate(
                         metrics,
                         "pass",
                         "criteria",
+                        legs=legs,
                     )
                 else:
                     reason = "verkeerde ratio"
@@ -187,6 +199,7 @@ def generate(
                         metrics,
                         "reject",
                         reason,
+                        legs=legs,
                     )
                     rejected_reasons.append(reason)
             else:
@@ -197,6 +210,7 @@ def generate(
                     metrics,
                     "reject",
                     reason,
+                    legs=legs,
                 )
                 if reasons:
                     rejected_reasons.extend(reasons)

--- a/tomic/strategies/short_call_spread.py
+++ b/tomic/strategies/short_call_spread.py
@@ -72,6 +72,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=[{"expiry": expiry}],
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -96,12 +97,19 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=[
+                        {"expiry": expiry, "strike": short_opt.get("strike"), "type": "C", "position": -1}
+                    ],
                 )
                 rejected_reasons.append(reason)
                 continue
             long_strike_target = float(short_opt.get("strike")) + width
             long_strike = _nearest_strike(strike_map, expiry, "C", long_strike_target)
             desc = f"short {short_opt.get('strike')} long {long_strike.matched}"
+            legs_info = [
+                {"expiry": expiry, "strike": short_opt.get("strike"), "type": "C", "position": -1},
+                {"expiry": expiry, "strike": long_strike.matched, "type": "C", "position": 1},
+            ]
             if not long_strike.matched:
                 reason = "long strike niet gevonden"
                 log_combo_evaluation(
@@ -110,6 +118,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=legs_info,
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -122,6 +131,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=legs_info,
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -137,6 +147,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=legs_info,
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -151,6 +162,7 @@ def generate(
                     metrics,
                     "pass",
                     "criteria",
+                    legs=legs,
                 )
             else:
                 reason = "; ".join(reasons) if reasons else "risk/reward onvoldoende"
@@ -160,6 +172,7 @@ def generate(
                     metrics,
                     "reject",
                     reason,
+                    legs=legs,
                 )
                 if reasons:
                     rejected_reasons.extend(reasons)

--- a/tomic/strategies/short_put_spread.py
+++ b/tomic/strategies/short_put_spread.py
@@ -72,6 +72,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=[{"expiry": expiry}],
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -96,12 +97,19 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=[
+                        {"expiry": expiry, "strike": short_opt.get("strike"), "type": "P", "position": -1}
+                    ],
                 )
                 rejected_reasons.append(reason)
                 continue
             long_strike_target = float(short_opt.get("strike")) - width
             long_strike = _nearest_strike(strike_map, expiry, "P", long_strike_target)
             desc = f"short {short_opt.get('strike')} long {long_strike.matched}"
+            legs_info = [
+                {"expiry": expiry, "strike": short_opt.get("strike"), "type": "P", "position": -1},
+                {"expiry": expiry, "strike": long_strike.matched, "type": "P", "position": 1},
+            ]
             if not long_strike.matched:
                 reason = "long strike niet gevonden"
                 log_combo_evaluation(
@@ -110,6 +118,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=legs_info,
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -122,6 +131,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=legs_info,
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -137,6 +147,7 @@ def generate(
                     None,
                     "reject",
                     reason,
+                    legs=legs_info,
                 )
                 rejected_reasons.append(reason)
                 continue
@@ -151,6 +162,7 @@ def generate(
                     metrics,
                     "pass",
                     "criteria",
+                    legs=legs,
                 )
             else:
                 reason = "; ".join(reasons) if reasons else "risk/reward onvoldoende"
@@ -160,6 +172,7 @@ def generate(
                     metrics,
                     "reject",
                     reason,
+                    legs=legs,
                 )
                 if reasons:
                     rejected_reasons.extend(reasons)


### PR DESCRIPTION
## Summary
- Extend `log_combo_evaluation` with `legs` parameter and include expiry/leg fields in log output
- Pass leg information from all strategy modules and document leg-aware logging
- Verify logging of leg details for iron condor and short call spread strategies

## Testing
- `pytest tests/analysis/test_iron_condor_logging.py tests/analysis/test_short_call_spread_logging.py`

------
https://chatgpt.com/codex/tasks/task_b_68b5e9bccb1c832e868a9e922fbcfc12