### PR TITLE
Normalize option type checks across strategies

### DIFF
--- a/tests/analysis/test_iron_condor_logging.py
+++ b/tests/analysis/test_iron_condor_logging.py
@@ -8,7 +8,7 @@ def _chain():
         {
             "expiry": "2025-01-01",
             "strike": 110,
-            "type": "C",
+            "type": "call",
             "bid": 1.0,
             "ask": 1.2,
             "delta": 0.4,
@@ -19,7 +19,7 @@ def _chain():
         {
             "expiry": "2025-01-01",
             "strike": 120,
-            "type": "C",
+            "type": "call",
             "bid": 0.5,
             "ask": 0.7,
             "delta": 0.2,
@@ -30,7 +30,7 @@ def _chain():
         {
             "expiry": "2025-01-01",
             "strike": 90,
-            "type": "P",
+            "type": "put",
             "bid": 1.0,
             "ask": 1.1,
             "delta": -0.3,
@@ -41,7 +41,7 @@ def _chain():
         {
             "expiry": "2025-01-01",
             "strike": 80,
-            "type": "P",
+            "type": "put",
             "bid": 0.4,
             "ask": 0.6,
             "delta": -0.1,
@@ -78,6 +78,6 @@ def test_iron_condor_logging(monkeypatch):
     assert "SP=90.0P" in joined and "LP=80.0P" in joined
 
     messages.clear()
-    chain_fail = [c for c in chain if c["type"] == "C"]
+    chain_fail = [c for c in chain if c["type"] == "call"]
     iron_condor.generate("AAA", chain_fail, cfg, 100.0, 1.0)
     assert any("short optie ontbreekt" in m and "expiry=2025-01-01" in m for m in messages)

--- a/tests/analysis/test_short_call_spread_logging.py
+++ b/tests/analysis/test_short_call_spread_logging.py
@@ -8,7 +8,7 @@ def _chain():
         {
             "expiry": "2025-01-01",
             "strike": 90,
-            "type": "P",
+            "type": "put",
             "bid": 1.0,
             "ask": 1.1,
             "delta": -0.3,

--- a/tests/analysis/test_strategy_minimal_chain.py
+++ b/tests/analysis/test_strategy_minimal_chain.py
@@ -4,20 +4,21 @@ from copy import deepcopy
 from tomic import strategy_candidates
 from tomic.strategy_candidates import generate_strategy_candidates
 from tomic.strategies.config_models import CONFIG_MODELS
+from tomic.utils import normalize_right
 
 # Base options chain with minimal coverage for all strategies
 BASE_CHAIN = [
-    {"expiry": "20250101", "strike": 100, "type": "C", "bid": 2.0, "ask": 2.2, "delta": 0.5, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
-    {"expiry": "20250101", "strike": 110, "type": "C", "bid": 5.0, "ask": 5.2, "delta": 0.4, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
-    {"expiry": "20250101", "strike": 120, "type": "C", "bid": 0.5, "ask": 0.6, "delta": 0.2, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
-    {"expiry": "20250101", "strike": 80, "type": "P", "bid": 0.5, "ask": 0.6, "delta": -0.1, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
-    {"expiry": "20250101", "strike": 90, "type": "P", "bid": 5.0, "ask": 5.2, "delta": -0.25, "edge": 5.0, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
-    {"expiry": "20250101", "strike": 100, "type": "P", "bid": 2.0, "ask": 2.2, "delta": -0.5, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
-    {"expiry": "20250301", "strike": 100, "type": "C", "bid": 5.0, "ask": 5.2, "delta": 0.45, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
-    {"expiry": "20250301", "strike": 100, "type": "P", "bid": 5.0, "ask": 5.2, "delta": -0.45, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
-    {"expiry": "20250301", "strike": 90, "type": "P", "bid": 1.0, "ask": 1.1, "delta": -0.2, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
-    {"expiry": "20250301", "strike": 80, "type": "P", "bid": 1.0, "ask": 1.1, "delta": -0.15, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
-    {"expiry": "20250301", "strike": 110, "type": "C", "bid": 1.0, "ask": 1.1, "delta": 0.35, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
+    {"expiry": "20250101", "strike": 100, "type": "call", "bid": 2.0, "ask": 2.2, "delta": 0.5, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
+    {"expiry": "20250101", "strike": 110, "type": "call", "bid": 5.0, "ask": 5.2, "delta": 0.4, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
+    {"expiry": "20250101", "strike": 120, "type": "call", "bid": 0.5, "ask": 0.6, "delta": 0.2, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
+    {"expiry": "20250101", "strike": 80, "type": "put", "bid": 0.5, "ask": 0.6, "delta": -0.1, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
+    {"expiry": "20250101", "strike": 90, "type": "put", "bid": 5.0, "ask": 5.2, "delta": -0.25, "edge": 5.0, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
+    {"expiry": "20250101", "strike": 100, "type": "put", "bid": 2.0, "ask": 2.2, "delta": -0.5, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
+    {"expiry": "20250301", "strike": 100, "type": "call", "bid": 5.0, "ask": 5.2, "delta": 0.45, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
+    {"expiry": "20250301", "strike": 100, "type": "put", "bid": 5.0, "ask": 5.2, "delta": -0.45, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
+    {"expiry": "20250301", "strike": 90, "type": "put", "bid": 1.0, "ask": 1.1, "delta": -0.2, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
+    {"expiry": "20250301", "strike": 80, "type": "put", "bid": 1.0, "ask": 1.1, "delta": -0.15, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
+    {"expiry": "20250301", "strike": 110, "type": "call", "bid": 1.0, "ask": 1.1, "delta": 0.35, "edge": 0.5, "model": 0, "iv": 0.2, "volume": 100, "open_interest": 1000},
 ]
 
 # Minimal valid configuration per strategy
@@ -128,18 +129,18 @@ def test_min_risk_reward_enforced(strategy, monkeypatch):
 
 def _set_mid(chain, opt_type, strike, price):
     for opt in chain:
-        if opt["type"] == opt_type and opt["strike"] == strike:
+        if normalize_right(opt["type"]) == normalize_right(opt_type) and opt["strike"] == strike:
             opt["bid"] = price
             opt["ask"] = price
 
 
 NEGATIVE_CHAIN_ADJUSTERS = {
-    "short_put_spread": lambda ch: _set_mid(ch, "P", 80, 20.0),
-    "short_call_spread": lambda ch: _set_mid(ch, "C", 120, 20.0),
-    "iron_condor": lambda ch: (_set_mid(ch, "C", 120, 20.0), _set_mid(ch, "P", 80, 20.0)),
+    "short_put_spread": lambda ch: _set_mid(ch, "put", 80, 20.0),
+    "short_call_spread": lambda ch: _set_mid(ch, "call", 120, 20.0),
+    "iron_condor": lambda ch: (_set_mid(ch, "call", 120, 20.0), _set_mid(ch, "put", 80, 20.0)),
     "atm_iron_butterfly": lambda ch: (
-        _set_mid(ch, "C", 110, 20.0),
-        _set_mid(ch, "P", 90, 20.0),
+        _set_mid(ch, "call", 110, 20.0),
+        _set_mid(ch, "put", 90, 20.0),
     ),
 }
 

--- a/tomic/strategies/backspread_put.py
+++ b/tomic/strategies/backspread_put.py
@@ -5,6 +5,7 @@ from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
 from . import StrategyName
 from .utils import compute_dynamic_width, make_leg, passes_risk
 from ..logutils import log_combo_evaluation
+from ..utils import normalize_right
 from ..strategy_candidates import (
     StrategyProposal,
     _build_strike_map,
@@ -62,7 +63,7 @@ def generate(
             for opt in option_chain:
                 if (
                     str(opt.get("expiry")) == near
-                    and (opt.get("type") or opt.get("right")) == "P"
+                    and normalize_right(opt.get("type") or opt.get("right")) == "put"
                     and opt.get("delta") is not None
                     and delta_range[0] <= float(opt.get("delta")) <= delta_range[1]
                 ):

--- a/tomic/strategies/iron_condor.py
+++ b/tomic/strategies/iron_condor.py
@@ -6,6 +6,7 @@ from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
 from . import StrategyName
 from .utils import compute_dynamic_width, make_leg, passes_risk
 from ..logutils import log_combo_evaluation
+from ..utils import normalize_right
 from ..strategy_candidates import (
     StrategyProposal,
     _build_strike_map,
@@ -56,7 +57,7 @@ def generate(
             o
             for o in option_chain
             if str(o.get("expiry")) == expiry
-            and (o.get("type") or o.get("right")) == "C"
+            and normalize_right(o.get("type") or o.get("right")) == "call"
             and o.get("delta") is not None
             and len(call_range) == 2
             and call_range[0] <= float(o["delta"]) <= call_range[1]
@@ -65,7 +66,7 @@ def generate(
             o
             for o in option_chain
             if str(o.get("expiry")) == expiry
-            and (o.get("type") or o.get("right")) == "P"
+            and normalize_right(o.get("type") or o.get("right")) == "put"
             and o.get("delta") is not None
             and len(put_range) == 2
             and put_range[0] <= float(o["delta"]) <= put_range[1]

--- a/tomic/strategies/naked_put.py
+++ b/tomic/strategies/naked_put.py
@@ -5,6 +5,7 @@ from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
 from . import StrategyName
 from .utils import make_leg, passes_risk
 from ..logutils import log_combo_evaluation
+from ..utils import normalize_right
 from ..strategy_candidates import (
     StrategyProposal,
     _metrics,
@@ -48,7 +49,7 @@ def generate(
             for opt in option_chain:
                 if (
                     str(opt.get("expiry")) == expiry
-                    and (opt.get("type") or opt.get("right")) == "P"
+                    and normalize_right(opt.get("type") or opt.get("right")) == "put"
                     and opt.get("delta") is not None
                     and delta_range[0] <= float(opt.get("delta")) <= delta_range[1]
                 ):

--- a/tomic/strategies/short_call_spread.py
+++ b/tomic/strategies/short_call_spread.py
@@ -5,6 +5,7 @@ from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
 from . import StrategyName
 from .utils import compute_dynamic_width, make_leg, passes_risk
 from ..logutils import log_combo_evaluation
+from ..utils import normalize_right
 from ..strategy_candidates import (
     StrategyProposal,
     _build_strike_map,
@@ -55,7 +56,7 @@ def generate(
             for opt in option_chain:
                 if (
                     str(opt.get("expiry")) == expiry
-                    and (opt.get("type") or opt.get("right")) == "C"
+                    and normalize_right(opt.get("type") or opt.get("right")) == "call"
                     and opt.get("delta") is not None
                     and delta_range[0] <= float(opt.get("delta")) <= delta_range[1]
                 ):

--- a/tomic/strategies/short_put_spread.py
+++ b/tomic/strategies/short_put_spread.py
@@ -5,6 +5,7 @@ from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
 from . import StrategyName
 from .utils import compute_dynamic_width, make_leg, passes_risk
 from ..logutils import log_combo_evaluation
+from ..utils import normalize_right
 from ..strategy_candidates import (
     StrategyProposal,
     _build_strike_map,
@@ -55,7 +56,7 @@ def generate(
             for opt in option_chain:
                 if (
                     str(opt.get("expiry")) == expiry
-                    and (opt.get("type") or opt.get("right")) == "P"
+                    and normalize_right(opt.get("type") or opt.get("right")) == "put"
                     and opt.get("delta") is not None
                     and delta_range[0] <= float(opt.get("delta")) <= delta_range[1]
                 ):

--- a/tomic/strategies/utils.py
+++ b/tomic/strategies/utils.py
@@ -10,7 +10,7 @@ from tomic.helpers.dateutils import dte_between_dates
 from tomic.helpers.timeutils import today
 
 from ..config import get as cfg_get
-from ..utils import get_option_mid_price, normalize_leg
+from ..utils import get_option_mid_price, normalize_leg, normalize_right
 from ..logutils import logger
 
 
@@ -120,11 +120,12 @@ def compute_dynamic_width(
             return None
 
     if target_delta is not None and option_chain and expiry and option_type:
+        opt_type = normalize_right(option_type)
         candidates = [
             o
             for o in option_chain
             if str(o.get("expiry")) == expiry
-            and (o.get("type") or o.get("right")) == option_type
+            and normalize_right(o.get("type") or o.get("right")) == opt_type
             and o.get("delta") is not None
         ]
         if not candidates:


### PR DESCRIPTION
## Summary
- Normalize option type comparisons to accept `call`/`put` as well as `C`/`P`
- Update dynamic width utility to use normalized option rights
- Extend strategy tests to cover full option type names

## Testing
- `pytest tests/analysis/test_iron_condor_logging.py tests/analysis/test_short_call_spread_logging.py tests/analysis/test_strategy_minimal_chain.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b5eeed24d4832ebb054db63b78046c