### PR TITLE
Introduce ConfigBase and config validators

### DIFF
--- a/criteria.yaml
+++ b/criteria.yaml
@@ -6,6 +6,9 @@
 # Tip: zet `EXPLAIN_FILTERS=true` of start met `--show-filter-stats` om te
 # zien hoeveel combinaties elke regel wegfiltert.
 
+# Schema version
+version: 1
+
 # 1) GENERIC STRIKE FILTERS
 strike:
   delta_min: -0.99

--- a/tests/analysis/test_liquidity_filter.py
+++ b/tests/analysis/test_liquidity_filter.py
@@ -44,6 +44,7 @@ def test_metrics_rejects_low_liquidity(monkeypatch):
     monkeypatch.setattr(sc, "logger", DummyLogger())
     base = load_criteria()
     criteria = CriteriaConfig(
+        version=base.version,
         strike=base.strike,
         strategy=base.strategy,
         market_data=MarketDataCriteria(

--- a/tests/analysis/test_nearest_strike.py
+++ b/tests/analysis/test_nearest_strike.py
@@ -29,13 +29,16 @@ def test_nearest_strike_uses_config():
     m = _build_strike_map(chain)
     base = load_criteria()
     criteria = CriteriaConfig(
+        version=base.version,
         strike=base.strike,
         strategy=base.strategy,
         market_data=base.market_data,
-        alerts=AlertCriteria(nearest_strike_tolerance_percent=5.0,
-                             skew_threshold=base.alerts.skew_threshold,
-                             iv_hv_min_spread=base.alerts.iv_hv_min_spread,
-                             iv_rank_threshold=base.alerts.iv_rank_threshold),
+        alerts=AlertCriteria(
+            nearest_strike_tolerance_percent=5.0,
+            skew_threshold=base.alerts.skew_threshold,
+            iv_hv_min_spread=base.alerts.iv_hv_min_spread,
+            iv_rank_threshold=base.alerts.iv_rank_threshold,
+        ),
         portfolio=base.portfolio,
     )
     res = _nearest_strike(m, "20250101", "c", 104, criteria=criteria)

--- a/tests/analysis/test_strategy_config_validation.py
+++ b/tests/analysis/test_strategy_config_validation.py
@@ -2,6 +2,10 @@ import pytest
 from pydantic import ValidationError
 
 from tomic.strategy_candidates import generate_strategy_candidates
+from tomic.strategies.config_models import (
+    IronCondorStrikeConfig,
+    ShortPutSpreadStrikeConfig,
+)
 
 
 @pytest.mark.parametrize(
@@ -19,3 +23,22 @@ def test_invalid_strike_config(strategy, cfg, monkeypatch):
     monkeypatch.setenv("TOMIC_TODAY", "2024-06-01")
     with pytest.raises(ValidationError):
         generate_strategy_candidates("AAA", strategy, [], 1.0, cfg, 100.0)
+
+
+def test_long_leg_distance_and_atr_are_mutually_exclusive():
+    with pytest.raises(ValidationError):
+        ShortPutSpreadStrikeConfig(
+            short_put_delta_range=(0.1, 0.2),
+            long_leg_distance_points=0.1,
+            long_leg_atr_multiple=1.0,
+        )
+
+
+def test_short_leg_width_points_and_ratio_are_mutually_exclusive():
+    with pytest.raises(ValidationError):
+        IronCondorStrikeConfig(
+            short_call_delta_range=(0.1, 0.2),
+            short_put_delta_range=(-0.2, -0.1),
+            short_leg_width_points=5,
+            short_leg_width_ratio=0.5,
+        )

--- a/tests/cli/test_rules_cli.py
+++ b/tests/cli/test_rules_cli.py
@@ -1,6 +1,7 @@
 from tomic.cli import rules
 
 VALID = """
+version: 1
 strike:
   delta_min: -0.8
   delta_max: 0.8

--- a/tomic/core/config_models.py
+++ b/tomic/core/config_models.py
@@ -1,0 +1,28 @@
+"""Shared configuration model utilities.
+
+This module defines small Pydantic helpers that are reused across
+configuration models.  At the moment it only exposes :class:`ConfigBase`
+which provides a ``version`` field so individual configuration files can
+declare their schema version explicitly.
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ConfigBase(BaseModel):
+    """Base model for configuration files.
+
+    All configuration roots should inherit from this model to ensure a
+    ``version`` attribute is present.  The field does not currently have any
+    semantics besides being an integer but it lays the groundwork for future
+    schema migrations.
+    """
+
+    version: int
+
+    # Reject unexpected fields to surface typos early.
+    model_config = ConfigDict(extra="forbid")
+
+
+__all__ = ["ConfigBase"]
+

--- a/tomic/criteria.py
+++ b/tomic/criteria.py
@@ -15,9 +15,10 @@ from pathlib import Path
 import math
 from typing import List
 
-from pydantic import BaseModel, model_validator, field_validator
+from pydantic import BaseModel, model_validator
 
-from .strategies import StrategyName
+from .strategies import StrategyName as StrategyNameEnum
+from .core.config_models import ConfigBase
 
 from .config import _load_yaml  # reuse YAML loader
 
@@ -43,19 +44,8 @@ class StrikeRules(BaseModel):
 class StrategyAcceptanceRules(BaseModel):
     """Rules governing which strategies are acceptable."""
 
-    require_positive_credit_for: List[str] = []
+    require_positive_credit_for: List[StrategyNameEnum] = []
     min_risk_reward: float | None = None
-
-    @field_validator("require_positive_credit_for")
-    @classmethod
-    def _validate_names(cls, v: List[str]) -> List[str]:
-        valid = {s.value for s in StrategyName}
-        invalid = [name for name in v if name not in valid]
-        if invalid:
-            raise ValueError(
-                "unknown strategy names: " + ", ".join(invalid)
-            )
-        return v
 
 
 class StrategyRules(BaseModel):
@@ -181,7 +171,7 @@ class AlertRules(BaseModel):
     )
 
 
-class RulesConfig(BaseModel):
+class RulesConfig(ConfigBase):
     """Root configuration object combining all rule sections."""
 
     strike: StrikeRules

--- a/tomic/strategies/config_models.py
+++ b/tomic/strategies/config_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import List, Tuple
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 
 class _BaseStrikeConfig(BaseModel):
@@ -13,6 +13,24 @@ class _BaseStrikeConfig(BaseModel):
     use_ATR: bool | None = None
 
     model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _validate_xor_fields(self):
+        """Ensure mutually exclusive strike parameters."""
+        lp = getattr(self, "long_leg_distance_points", None)
+        la = getattr(self, "long_leg_atr_multiple", None)
+        if lp is not None and la is not None:
+            raise ValueError(
+                "long_leg_distance_points and long_leg_atr_multiple are mutually exclusive"
+            )
+
+        sp = getattr(self, "short_leg_width_points", None)
+        sr = getattr(self, "short_leg_width_ratio", None)
+        if sp is not None and sr is not None:
+            raise ValueError(
+                "short_leg_width_points and short_leg_width_ratio are mutually exclusive"
+            )
+        return self
 
 
 class _BaseConfig(BaseModel):
@@ -64,6 +82,8 @@ class IronCondorStrikeConfig(_BaseStrikeConfig):
     short_call_delta_range: Tuple[float, float]
     short_put_delta_range: Tuple[float, float]
     wing_sigma_multiple: float | None = None
+    short_leg_width_points: float | None = None
+    short_leg_width_ratio: float | None = None
 
 
 class IronCondorConfig(_BaseConfig):

--- a/tomic/strategy_candidates.py
+++ b/tomic/strategy_candidates.py
@@ -36,10 +36,9 @@ from .config import _asdict
 
 
 # Strategies that must yield a positive net credit are configured via RULES.
-POSITIVE_CREDIT_STRATS = {
-    StrategyName(s)
-    for s in RULES.strategy.acceptance.require_positive_credit_for
-}
+POSITIVE_CREDIT_STRATS = set(
+    RULES.strategy.acceptance.require_positive_credit_for
+)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add shared ConfigBase with version field and apply it to rules config
- validate strategy names via enums and enforce mutually exclusive strike params
- test config validators and update configs to include version

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b805d9673c832e8df5661ce1baf32c