### PR TITLE
refactor price history loading into helper

### DIFF
--- a/tests/cli/test_show_pricehistory.py
+++ b/tests/cli/test_show_pricehistory.py
@@ -12,7 +12,7 @@ def test_show_pricehistory(monkeypatch, capsys, tmp_path):
         {"date": "2024-01-01", "close": 1.23, "volume": 100, "atr": None},
         {"date": "2024-01-02", "close": 1.25, "volume": 120, "atr": None},
     ], file)
-    monkeypatch.setattr(mod, "cfg_get", lambda name, default=None: str(tmp) if name == "PRICE_HISTORY_DIR" else default)
+    monkeypatch.setattr("tomic.utils.cfg_get", lambda name, default=None: str(tmp) if name == "PRICE_HISTORY_DIR" else default)
     monkeypatch.setattr(mod, "setup_logging", lambda: None)
 
     mod.main(["AAA"])

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -23,6 +23,27 @@ def test_get_option_mid_price_fallback_close():
     assert utils.get_option_mid_price(option) == 0.8
 
 
+def test_load_price_history(monkeypatch, tmp_path):
+    data = [
+        {"date": "2024-01-02", "close": 101.0},
+        {"date": "2024-01-01", "close": 100.0},
+    ]
+    path = tmp_path / "AAA.json"
+    path.write_text(json.dumps(data))
+
+    monkeypatch.setattr(
+        utils,
+        "cfg_get",
+        lambda name, default=None: str(tmp_path)
+        if name == "PRICE_HISTORY_DIR"
+        else default,
+    )
+    importlib.reload(utils)
+
+    records = utils.load_price_history("AAA")
+    assert [r.get("date") for r in records] == ["2024-01-01", "2024-01-02"]
+
+
 def test_latest_atr(monkeypatch, tmp_path):
     data = [
         {"date": "2024-01-01", "close": 100.0, "atr": None},

--- a/tomic/cli/compute_volstats_polygon.py
+++ b/tomic/cli/compute_volstats_polygon.py
@@ -9,22 +9,24 @@ from typing import List, Any
 
 from tomic.analysis.metrics import historical_volatility
 from tomic.config import get as cfg_get
-from tomic.journal.utils import load_json, update_json_file
+from tomic.journal.utils import update_json_file
 from tomic.logutils import logger, setup_logging
 from tomic.providers.polygon_iv import fetch_polygon_iv30d
 from tomic.polygon_client import PolygonClient
 from tomic.helpers.price_utils import _load_latest_close
+from tomic.utils import load_price_history
 
 
 def _get_closes(symbol: str) -> list[float]:
     """Return list of close prices for ``symbol`` sorted by date."""
-    base = Path(cfg_get("PRICE_HISTORY_DIR", "tomic/data/spot_prices"))
-    path = base / f"{symbol}.json"
-    data = load_json(path)
-    if not isinstance(data, list):
-        return []
-    data.sort(key=lambda r: r.get("date", ""))
-    return [float(rec.get("close", 0)) for rec in data]
+    data = load_price_history(symbol)
+    closes: list[float] = []
+    for rec in data:
+        try:
+            closes.append(float(rec.get("close", 0)))
+        except Exception:
+            continue
+    return closes
 
 
 

--- a/tomic/cli/controlpanel.py
+++ b/tomic/cli/controlpanel.py
@@ -69,7 +69,7 @@ from tomic.helpers.price_meta import load_price_meta, save_price_meta
 from tomic.polygon_client import PolygonClient
 from tomic.strike_selector import StrikeSelector, filter_by_expiry, FilterConfig
 from tomic.loader import load_strike_config
-from tomic.utils import get_option_mid_price, latest_atr, normalize_leg
+from tomic.utils import get_option_mid_price, latest_atr, normalize_leg, load_price_history
 from tomic.helpers.csv_utils import normalize_european_number_format
 from tomic.helpers.interpolation import interpolate_missing_fields
 from tomic.helpers.quality_check import calculate_csv_quality
@@ -372,13 +372,8 @@ def run_dataexporter() -> None:
         if not symbol:
             print("Geen symbool opgegeven")
             return
-        base = Path(cfg.get("PRICE_HISTORY_DIR", "tomic/data/spot_prices"))
-        data = load_json(base / f"{symbol.upper()}.json")
-        rows = (
-            [[rec.get("date"), rec.get("close")] for rec in data[-10:]]
-            if isinstance(data, list)
-            else []
-        )
+        data = load_price_history(symbol.upper())
+        rows = [[rec.get("date"), rec.get("close")] for rec in data[-10:]] if data else []
         if not rows:
             print("⚠️ Geen data gevonden")
             return

--- a/tomic/cli/show_pricehistory.py
+++ b/tomic/cli/show_pricehistory.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 from typing import List
 
 from tomic.config import get as cfg_get
-from pathlib import Path
-from tomic.journal.utils import load_json
 from tomic.logutils import setup_logging
+from tomic.utils import load_price_history
 
 try:
     from tabulate import tabulate
@@ -40,13 +39,12 @@ def main(argv: List[str] | None = None) -> None:
         argv = []
     symbols = [s.upper() for s in argv] if argv else [s.upper() for s in cfg_get("DEFAULT_SYMBOLS", [])]
 
-    base = Path(cfg_get("PRICE_HISTORY_DIR", "tomic/data/spot_prices"))
     for sym in symbols:
-        data = load_json(base / f"{sym}.json")
+        data = load_price_history(sym)
         rows = [
             [rec.get("date"), rec.get("close"), rec.get("volume"), rec.get("atr")]
             for rec in data
-        ] if isinstance(data, list) else []
+        ]
         if rows:
             print(f"\n=== {sym} ===")
             headers = ["date", "close", "volume", "atr"]

--- a/tomic/helpers/price_utils.py
+++ b/tomic/helpers/price_utils.py
@@ -1,20 +1,15 @@
 from __future__ import annotations
 """Price-related helper utilities."""
 
-from pathlib import Path
-from tomic.config import get as cfg_get
 from tomic.logutils import logger
-from tomic.journal.utils import load_json
+from tomic.utils import load_price_history
 
 
 def _load_latest_close(symbol: str) -> tuple[float | None, str | None]:
     """Return the most recent close and its date for ``symbol``."""
-    base = Path(cfg_get("PRICE_HISTORY_DIR", "tomic/data/spot_prices"))
-    path = base / f"{symbol}.json"
-    logger.debug(f"Loading close price for {symbol} from {path}")
-    data = load_json(path)
-    if isinstance(data, list) and data:
-        data.sort(key=lambda r: r.get("date", ""))
+    logger.debug(f"Loading close price for {symbol}")
+    data = load_price_history(symbol)
+    if data:
         rec = data[-1]
         try:
             price = float(rec.get("close"))

--- a/tomic/providers/polygon_iv.py
+++ b/tomic/providers/polygon_iv.py
@@ -7,7 +7,7 @@ from zoneinfo import ZoneInfo
 from pathlib import Path
 from typing import Any, Dict, List
 from tomic.utils import today
-from tomic.utils import _is_third_friday, _is_weekly
+from tomic.utils import _is_third_friday, _is_weekly, load_price_history
 import json
 import time
 import csv
@@ -31,12 +31,7 @@ from tomic.helpers.price_utils import _load_latest_close
 
 def _get_closes(symbol: str) -> list[float]:
     """Return list of closing prices sorted by date for ``symbol``."""
-    base = Path(cfg_get("PRICE_HISTORY_DIR", "tomic/data/spot_prices"))
-    path = base / f"{symbol}.json"
-    data = load_json(path)
-    if not isinstance(data, list):
-        return []
-    data.sort(key=lambda r: r.get("date", ""))
+    data = load_price_history(symbol)
     closes: list[float] = []
     for rec in data:
         try:

--- a/tomic/scripts/backfill_hv.py
+++ b/tomic/scripts/backfill_hv.py
@@ -9,26 +9,21 @@ from typing import Iterable, List
 from tomic.config import get as cfg_get
 from tomic.journal.utils import load_json, save_json
 from tomic.logutils import logger, setup_logging
-from tomic.utils import today
+from tomic.utils import today, load_price_history
 
 
 def _load_price_data(symbol: str) -> list[tuple[str, float]]:
     """Return list of (date, close) tuples sorted by date."""
-    base = Path(cfg_get("PRICE_HISTORY_DIR", "tomic/data/spot_prices"))
-    path = base / f"{symbol}.json"
-    data = load_json(path)
     records: list[tuple[str, float]] = []
-    if isinstance(data, list):
-        for rec in data:
-            d = rec.get("date")
-            c = rec.get("close")
-            if d is None or c is None:
-                continue
-            try:
-                records.append((str(d), float(c)))
-            except Exception:
-                continue
-    records.sort(key=lambda r: r[0])
+    for rec in load_price_history(symbol):
+        d = rec.get("date")
+        c = rec.get("close")
+        if d is None or c is None:
+            continue
+        try:
+            records.append((str(d), float(c)))
+        except Exception:
+            continue
     return records
 
 


### PR DESCRIPTION
## Summary
- add `load_price_history` utility to centralize reading and sorting price history JSON files
- reuse new helper in `latest_close_date`, `latest_atr`, and other modules
- expand tests to cover price history loading and adjust patches

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b87c3c704c832eacf4a1f89d6130c2