### PR TITLE
feat: centralize leg right normalization

### DIFF
--- a/tests/analysis/test_strategy_candidates_new.py
+++ b/tests/analysis/test_strategy_candidates_new.py
@@ -1,6 +1,7 @@
 import pytest
 from tomic.strategies import iron_condor
 from tomic.strategy_candidates import _metrics
+from tomic.utils import get_leg_right
 
 
 def test_generate_strategy_candidates_requires_spot():
@@ -163,7 +164,7 @@ def test_parity_mid_used_for_missing_bidask(monkeypatch):
             l
             for l in props[0].legs
             if l.get("position") < 0
-            and (l.get("type") or l.get("right")) == "C"
+            and get_leg_right(l) == "call"
             and float(l.get("strike")) == 110
         ),
         None,

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -31,6 +31,7 @@ def test_load_price_history(monkeypatch, tmp_path):
     path = tmp_path / "AAA.json"
     path.write_text(json.dumps(data))
 
+    importlib.reload(utils)
     monkeypatch.setattr(
         utils,
         "cfg_get",
@@ -38,7 +39,6 @@ def test_load_price_history(monkeypatch, tmp_path):
         if name == "PRICE_HISTORY_DIR"
         else default,
     )
-    importlib.reload(utils)
 
     records = utils.load_price_history("AAA")
     assert [r.get("date") for r in records] == ["2024-01-01", "2024-01-02"]
@@ -53,12 +53,12 @@ def test_latest_atr(monkeypatch, tmp_path):
     path = tmp_path / "AAA.json"
     path.write_text(json.dumps(data))
 
+    importlib.reload(utils)
     monkeypatch.setattr(
         utils, "cfg_get", lambda name, default=None: str(tmp_path)
         if name == "PRICE_HISTORY_DIR"
         else default,
     )
-    importlib.reload(utils)
 
     assert utils.latest_atr("AAA") == 1.5
 
@@ -67,12 +67,12 @@ def test_latest_atr_none(monkeypatch, tmp_path):
     path = tmp_path / "AAA.json"
     path.write_text("[]")
 
+    importlib.reload(utils)
     monkeypatch.setattr(
         utils, "cfg_get", lambda name, default=None: str(tmp_path)
         if name == "PRICE_HISTORY_DIR"
         else default,
     )
-    importlib.reload(utils)
 
     assert utils.latest_atr("AAA") is None
 
@@ -132,5 +132,15 @@ def test_get_option_mid_price_nan_bid_ask():
 def test_get_option_mid_price_nan_close():
     option = {"bid": None, "ask": None, "close": "NaN"}
     assert utils.get_option_mid_price(option) is None
+
+
+def test_get_leg_right_prefers_right():
+    leg = {"right": "P", "type": "C"}
+    assert utils.get_leg_right(leg) == "put"
+
+
+def test_get_leg_right_fallback_type():
+    leg = {"type": "C"}
+    assert utils.get_leg_right(leg) == "call"
 
 

--- a/tomic/metrics.py
+++ b/tomic/metrics.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from math import inf
 from typing import Optional, Iterable, Any, Dict, List
 
-from .utils import normalize_right
+from .utils import get_leg_right
 from .logutils import logger
 from .config import get as cfg_get
 
@@ -107,7 +107,7 @@ def calculate_payoff_at_spot(
             )
         )
         position = _option_direction(leg) * qty
-        right = normalize_right(leg.get("type") or leg.get("right"))
+        right = get_leg_right(leg)
         strike = float(leg.get("strike"))
         if right == "call":
             intrinsic = max(spot_price - strike, 0)
@@ -173,7 +173,7 @@ def _max_loss(
         _option_direction(leg)
         * abs(float(leg.get("qty") or leg.get("quantity") or leg.get("position") or 1))
         for leg in legs
-        if normalize_right(leg.get("type") or leg.get("right")) == "call"
+        if get_leg_right(leg) == "call"
     )
     if slope_high < 0:
         return inf
@@ -229,12 +229,12 @@ def calculate_margin(
         puts = [
             float(l.get("strike"))
             for l in legs
-            if normalize_right(l.get("type") or l.get("right")) == "put"
+            if get_leg_right(l) == "put"
         ]
         calls = [
             float(l.get("strike"))
             for l in legs
-            if normalize_right(l.get("type") or l.get("right")) == "call"
+            if get_leg_right(l) == "call"
         ]
         if len(puts) != 2 or len(calls) != 2:
             raise ValueError("Invalid iron_condor/atm_iron_butterfly structure")

--- a/tomic/strategies/backspread_put.py
+++ b/tomic/strategies/backspread_put.py
@@ -7,7 +7,7 @@ from .utils import compute_dynamic_width
 from ..helpers.analysis.scoring import build_leg
 from ..analysis.scoring import calculate_score, passes_risk
 from ..logutils import log_combo_evaluation
-from ..utils import normalize_right
+from ..utils import get_leg_right
 from ..strategy_candidates import (
     StrategyProposal,
     _build_strike_map,
@@ -64,7 +64,7 @@ def generate(
             for opt in option_chain:
                 if (
                     str(opt.get("expiry")) == near
-                    and normalize_right(opt.get("type") or opt.get("right")) == "put"
+                    and get_leg_right(opt) == "put"
                     and opt.get("delta") is not None
                     and delta_range[0] <= float(opt.get("delta")) <= delta_range[1]
                 ):

--- a/tomic/strategies/iron_condor.py
+++ b/tomic/strategies/iron_condor.py
@@ -8,7 +8,7 @@ from .utils import compute_dynamic_width
 from ..helpers.analysis.scoring import build_leg
 from ..analysis.scoring import calculate_score, passes_risk
 from ..logutils import log_combo_evaluation
-from ..utils import normalize_right
+from ..utils import get_leg_right
 from ..strategy_candidates import (
     StrategyProposal,
     _build_strike_map,
@@ -58,7 +58,7 @@ def generate(
             o
             for o in option_chain
             if str(o.get("expiry")) == expiry
-            and normalize_right(o.get("type") or o.get("right")) == "call"
+            and get_leg_right(o) == "call"
             and o.get("delta") is not None
             and len(call_range) == 2
             and call_range[0] <= float(o["delta"]) <= call_range[1]
@@ -67,7 +67,7 @@ def generate(
             o
             for o in option_chain
             if str(o.get("expiry")) == expiry
-            and normalize_right(o.get("type") or o.get("right")) == "put"
+            and get_leg_right(o) == "put"
             and o.get("delta") is not None
             and len(put_range) == 2
             and put_range[0] <= float(o["delta"]) <= put_range[1]

--- a/tomic/strategies/naked_put.py
+++ b/tomic/strategies/naked_put.py
@@ -6,7 +6,7 @@ from . import StrategyName
 from ..helpers.analysis.scoring import build_leg
 from ..analysis.scoring import calculate_score, passes_risk
 from ..logutils import log_combo_evaluation
-from ..utils import normalize_right
+from ..utils import get_leg_right
 from ..strategy_candidates import (
     StrategyProposal,
 )
@@ -49,7 +49,7 @@ def generate(
             for opt in option_chain:
                 if (
                     str(opt.get("expiry")) == expiry
-                    and normalize_right(opt.get("type") or opt.get("right")) == "put"
+                    and get_leg_right(opt) == "put"
                     and opt.get("delta") is not None
                     and delta_range[0] <= float(opt.get("delta")) <= delta_range[1]
                 ):

--- a/tomic/strategies/ratio_spread.py
+++ b/tomic/strategies/ratio_spread.py
@@ -7,7 +7,7 @@ from . import StrategyName
 from .utils import compute_dynamic_width
 from ..helpers.analysis.scoring import build_leg
 from ..analysis.scoring import calculate_score, passes_risk
-from ..utils import get_option_mid_price, normalize_right
+from ..utils import get_option_mid_price, get_leg_right
 from ..logutils import log_combo_evaluation
 from ..strategy_candidates import (
     StrategyProposal,
@@ -61,7 +61,7 @@ def generate(
                 if str(opt.get("expiry")) != expiry:
                     rejected_reasons.append("verkeerde expiratie")
                     continue
-                if normalize_right(opt.get("type") or opt.get("right")) != "call":
+                if get_leg_right(opt) != "call":
                     rejected_reasons.append("geen call optie")
                     continue
                 delta = opt.get("delta")
@@ -82,7 +82,7 @@ def generate(
             for opt in option_chain:
                 if (
                     str(opt.get("expiry")) == expiry
-                    and normalize_right(opt.get("type") or opt.get("right")) == "call"
+                    and get_leg_right(opt) == "call"
                     and opt.get("delta") is not None
                     and delta_range[0] <= float(opt.get("delta")) <= delta_range[1]
                 ):

--- a/tomic/strategies/short_call_spread.py
+++ b/tomic/strategies/short_call_spread.py
@@ -7,7 +7,7 @@ from .utils import compute_dynamic_width
 from ..helpers.analysis.scoring import build_leg
 from ..analysis.scoring import calculate_score, passes_risk
 from ..logutils import log_combo_evaluation
-from ..utils import normalize_right
+from ..utils import get_leg_right
 from ..strategy_candidates import (
     StrategyProposal,
     _build_strike_map,
@@ -57,7 +57,7 @@ def generate(
             for opt in option_chain:
                 if (
                     str(opt.get("expiry")) == expiry
-                    and normalize_right(opt.get("type") or opt.get("right")) == "call"
+                    and get_leg_right(opt) == "call"
                     and opt.get("delta") is not None
                     and delta_range[0] <= float(opt.get("delta")) <= delta_range[1]
                 ):

--- a/tomic/strategies/short_put_spread.py
+++ b/tomic/strategies/short_put_spread.py
@@ -7,7 +7,7 @@ from .utils import compute_dynamic_width
 from ..helpers.analysis.scoring import build_leg
 from ..analysis.scoring import calculate_score, passes_risk
 from ..logutils import log_combo_evaluation
-from ..utils import normalize_right
+from ..utils import get_leg_right
 from ..strategy_candidates import (
     StrategyProposal,
     _build_strike_map,
@@ -57,7 +57,7 @@ def generate(
             for opt in option_chain:
                 if (
                     str(opt.get("expiry")) == expiry
-                    and normalize_right(opt.get("type") or opt.get("right")) == "put"
+                    and get_leg_right(opt) == "put"
                     and opt.get("delta") is not None
                     and delta_range[0] <= float(opt.get("delta")) <= delta_range[1]
                 ):

--- a/tomic/strategies/utils.py
+++ b/tomic/strategies/utils.py
@@ -7,7 +7,7 @@ from typing import Sequence, Any, Dict, List, Mapping, Tuple
 
 from tomic.helpers.dateutils import dte_between_dates
 
-from ..utils import normalize_right, today
+from ..utils import normalize_right, get_leg_right, today
 from ..logutils import logger
 from ..helpers.analysis.scoring import build_leg
 
@@ -123,7 +123,7 @@ def compute_dynamic_width(
             o
             for o in option_chain
             if str(o.get("expiry")) == expiry
-            and normalize_right(o.get("type") or o.get("right")) == opt_type
+            and get_leg_right(o) == opt_type
             and o.get("delta") is not None
         ]
         if not candidates:

--- a/tomic/strategy_candidates.py
+++ b/tomic/strategy_candidates.py
@@ -15,6 +15,7 @@ from .utils import (
     get_option_mid_price,
     normalize_leg,
     normalize_right,
+    get_leg_right,
     prompt_user_for_price,
 )
 from .logutils import logger, log_combo_evaluation
@@ -101,13 +102,13 @@ def _breakevens(
             l
             for l in legs
             if l.get("position") < 0
-            and normalize_right(l.get("type") or l.get("right")) == "put"
+            and get_leg_right(l) == "put"
         ]
         short_call = [
             l
             for l in legs
             if l.get("position") < 0
-            and normalize_right(l.get("type") or l.get("right")) == "call"
+            and get_leg_right(l) == "call"
         ]
         if short_put and short_call:
             sp = float(short_put[0].get("strike"))
@@ -129,7 +130,7 @@ def _build_strike_map(chain: List[Dict[str, Any]]) -> Dict[str, Dict[str, List[f
     for opt in chain:
         try:
             expiry = str(opt.get("expiry"))
-            right = normalize_right(opt.get("type") or opt.get("right", ""))
+            right = get_leg_right(opt)
             strike = float(opt.get("strike"))
         except Exception:
             continue
@@ -151,7 +152,7 @@ def _options_by_strike(
     norm_right = normalize_right(right)
     for opt in chain:
         try:
-            opt_right = normalize_right(opt.get("type") or opt.get("right"))
+            opt_right = get_leg_right(opt)
             if opt_right != norm_right:
                 continue
             strike = float(opt.get("strike"))
@@ -238,7 +239,7 @@ def _find_option(
     for opt in chain:
         try:
             opt_exp = _norm_exp(opt.get("expiry"))
-            opt_right = _norm_right(opt.get("type") or opt.get("right"))
+            opt_right = get_leg_right(opt)
             opt_strike = float(opt.get("strike"))
             if (
                 opt_exp == target_exp

--- a/tomic/utils.py
+++ b/tomic/utils.py
@@ -176,6 +176,18 @@ def normalize_right(val: str) -> str:
     return ""
 
 
+def get_leg_right(leg: dict) -> str:
+    """Return normalized option right for ``leg``.
+
+    The ``leg`` dictionary may define the option right under either the
+    ``right`` or ``type`` key.  This helper fetches whichever is available and
+    returns it normalized as ``"call"`` or ``"put"`` using
+    :func:`normalize_right`.
+    """
+
+    return normalize_right(leg.get("right") or leg.get("type"))
+
+
 def latest_atr(symbol: str) -> float | None:
     """Return the most recent ATR value for ``symbol`` from price history."""
 


### PR DESCRIPTION
## Summary
- add reusable `get_leg_right` helper for option legs
- refactor strategy and candidate modules to use `get_leg_right`
- cover leg right helper with tests and update existing expectations

## Testing
- `pytest tests/helpers/test_utils.py tests/analysis/test_strategy_candidates_new.py`

------
https://chatgpt.com/codex/tasks/task_b_68b884351c04832e8b005d8ef30a5385