### PR TITLE
Refactor leg quantity handling and add tests

### DIFF
--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -144,3 +144,22 @@ def test_get_leg_right_fallback_type():
     assert utils.get_leg_right(leg) == "call"
 
 
+def test_get_leg_qty_prefers_qty():
+    leg = {"qty": 2, "quantity": 4, "position": 5}
+    assert utils.get_leg_qty(leg) == 2.0
+
+
+def test_get_leg_qty_fallback_quantity():
+    leg = {"quantity": "3"}
+    assert utils.get_leg_qty(leg) == 3.0
+
+
+def test_get_leg_qty_fallback_position():
+    leg = {"position": -6}
+    assert utils.get_leg_qty(leg) == 6.0
+
+
+def test_get_leg_qty_default_one():
+    assert utils.get_leg_qty({}) == 1.0
+
+

--- a/tomic/analysis/scoring.py
+++ b/tomic/analysis/scoring.py
@@ -12,7 +12,7 @@ from ..metrics import (
 )
 from ..analysis.strategy import heuristic_risk_metrics
 from ..criteria import CriteriaConfig, RULES, load_criteria
-from ..utils import normalize_leg
+from ..utils import normalize_leg, get_leg_qty
 from ..logutils import logger
 
 if TYPE_CHECKING:
@@ -206,14 +206,7 @@ def calculate_score(
         if math.isnan(mid_val):
             missing_mid.append(str(leg.get("strike")))
             continue
-        qty = abs(
-            float(
-                leg.get("qty")
-                or leg.get("quantity")
-                or leg.get("position")
-                or 1
-            )
-        )
+        qty = get_leg_qty(leg)
         pos = float(leg.get("position") or 0)
         if pos < 0:
             credits.append(mid_val * qty)

--- a/tomic/metrics.py
+++ b/tomic/metrics.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from math import inf
 from typing import Optional, Iterable, Any, Dict, List
 
-from .utils import get_leg_right
+from .utils import get_leg_right, get_leg_qty
 from .logutils import logger
 from .config import get as cfg_get
 
@@ -32,14 +32,7 @@ def calculate_credit(legs: Iterable[dict]) -> float:
             price = float(leg.get("mid", 0) or 0)
         except Exception:
             continue
-        qty = abs(
-            float(
-                leg.get("qty")
-                or leg.get("quantity")
-                or leg.get("position")
-                or 1
-            )
-        )
+        qty = get_leg_qty(leg)
         direction = 1 if leg.get("position", 0) > 0 else -1
         credit -= direction * price * qty
     return credit * 100
@@ -86,26 +79,12 @@ def calculate_payoff_at_spot(
         net_cashflow = 0.0
         for leg in legs:
             price = float(leg.get("mid", 0) or 0)
-            qty = abs(
-                float(
-                    leg.get("qty")
-                    or leg.get("quantity")
-                    or leg.get("position")
-                    or 1
-                )
-            )
+            qty = get_leg_qty(leg)
             net_cashflow += price * _option_direction(leg) * qty
 
     total = -net_cashflow * 100
     for leg in legs:
-        qty = abs(
-            float(
-                leg.get("qty")
-                or leg.get("quantity")
-                or leg.get("position")
-                or 1
-            )
-        )
+        qty = get_leg_qty(leg)
         position = _option_direction(leg) * qty
         right = get_leg_right(leg)
         strike = float(leg.get("strike"))

--- a/tomic/utils.py
+++ b/tomic/utils.py
@@ -188,6 +188,19 @@ def get_leg_right(leg: dict) -> str:
     return normalize_right(leg.get("right") or leg.get("type"))
 
 
+def get_leg_qty(leg: dict) -> float:
+    """Return absolute quantity for ``leg``.
+
+    The quantity may be specified under the ``"qty"``, ``"quantity"`` or
+    ``"position"`` keys. If none of these keys are present, a default quantity
+    of ``1`` is assumed.
+    """
+
+    return abs(
+        float(leg.get("qty") or leg.get("quantity") or leg.get("position") or 1)
+    )
+
+
 def latest_atr(symbol: str) -> float | None:
     """Return the most recent ATR value for ``symbol`` from price history."""
 


### PR DESCRIPTION
## Summary
- add `get_leg_qty` helper to unify leg quantity extraction
- refactor metrics credit/payoff calculations and analysis scoring to reuse `get_leg_qty`
- test helper across possible quantity sources

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b88ae30a9c832e91721de36e6533c3