### PR TITLE
refactor: add option-chain helpers and short vertical generator

### DIFF
--- a/tomic/strategies/short_call_spread.py
+++ b/tomic/strategies/short_call_spread.py
@@ -1,20 +1,10 @@
 from __future__ import annotations
+
 from typing import Any, Dict, List
-import pandas as pd
-from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
+
 from . import StrategyName
-from .utils import compute_dynamic_width
-from ..helpers.analysis.scoring import build_leg
-from ..analysis.scoring import calculate_score, passes_risk
-from ..logutils import log_combo_evaluation
-from ..utils import get_leg_right
-from ..strategy_candidates import (
-    StrategyProposal,
-    _build_strike_map,
-    _nearest_strike,
-    _find_option,
-)
-from ..strike_selector import _dte
+from ..strategy_candidates import StrategyProposal
+from .utils import generate_short_vertical
 
 
 def generate(
@@ -24,156 +14,19 @@ def generate(
     spot: float,
     atr: float,
 ) -> tuple[List[StrategyProposal], list[str]]:
-    rules = config.get("strike_to_strategy_config", {})
-    use_atr = bool(rules.get("use_ATR"))
-    if spot is None:
-        raise ValueError("spot price is required")
-    expiries = sorted({str(o.get("expiry")) for o in option_chain})
-    if not expiries:
-        return [], ["geen expiraties beschikbaar"]
-    strike_map = _build_strike_map(option_chain)
-    if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):
-        df_chain = pd.DataFrame(option_chain)
-        if spot > 0:
-            if "expiration" not in df_chain.columns and "expiry" in df_chain.columns:
-                df_chain["expiration"] = df_chain["expiry"]
-            df_chain = fill_missing_mid_with_parity(df_chain, spot=spot)
-            option_chain = df_chain.to_dict(orient="records")
-    proposals: List[StrategyProposal] = []
-    rejected_reasons: list[str] = []
-    min_rr = float(config.get("min_risk_reward", 0.0))
+    """Generate short call spread proposals using shared vertical logic."""
 
-    delta_range = rules.get("short_call_delta_range") or []
-    target_delta = rules.get("long_leg_distance_points")
-    atr_mult = rules.get("long_leg_atr_multiple")
-    dte_range = rules.get("dte_range")
-    if len(delta_range) == 2 and (target_delta is not None or atr_mult is not None):
-        for expiry in expiries:
-            if dte_range:
-                dte = _dte(expiry)
-                if dte is None or not (dte_range[0] <= dte <= dte_range[1]):
-                    continue
-            short_opt = None
-            for opt in option_chain:
-                if (
-                    str(opt.get("expiry")) == expiry
-                    and get_leg_right(opt) == "call"
-                    and opt.get("delta") is not None
-                    and delta_range[0] <= float(opt.get("delta")) <= delta_range[1]
-                ):
-                    short_opt = opt
-                    break
-            if not short_opt:
-                reason = "short optie ontbreekt"
-                desc = (
-                    f"target_delta {target_delta}" if target_delta is not None else f"atr_mult {atr_mult}"
-                )
-                log_combo_evaluation(
-                    StrategyName.SHORT_CALL_SPREAD,
-                    desc,
-                    None,
-                    "reject",
-                    reason,
-                    legs=[{"expiry": expiry}],
-                )
-                rejected_reasons.append(reason)
-                continue
-            width = compute_dynamic_width(
-                short_opt,
-                target_delta=target_delta,
-                atr_multiple=atr_mult,
-                atr=atr,
-                use_atr=use_atr,
-                option_chain=option_chain,
-                expiry=expiry,
-                option_type="C",
-            )
-            if width is None:
-                reason = "breedte niet berekend"
-                desc = (
-                    f"target_delta {target_delta}" if target_delta is not None else f"atr_mult {atr_mult}"
-                )
-                log_combo_evaluation(
-                    StrategyName.SHORT_CALL_SPREAD,
-                    desc,
-                    None,
-                    "reject",
-                    reason,
-                    legs=[
-                        {"expiry": expiry, "strike": short_opt.get("strike"), "type": "C", "position": -1}
-                    ],
-                )
-                rejected_reasons.append(reason)
-                continue
-            long_strike_target = float(short_opt.get("strike")) + width
-            long_strike = _nearest_strike(strike_map, expiry, "C", long_strike_target)
-            desc = f"short {short_opt.get('strike')} long {long_strike.matched}"
-            legs_info = [
-                {"expiry": expiry, "strike": short_opt.get("strike"), "type": "C", "position": -1},
-                {"expiry": expiry, "strike": long_strike.matched, "type": "C", "position": 1},
-            ]
-            if not long_strike.matched:
-                reason = "long strike niet gevonden"
-                log_combo_evaluation(
-                    StrategyName.SHORT_CALL_SPREAD,
-                    desc,
-                    None,
-                    "reject",
-                    reason,
-                    legs=legs_info,
-                )
-                rejected_reasons.append(reason)
-                continue
-            long_opt = _find_option(option_chain, expiry, long_strike.matched, "C")
-            if not long_opt:
-                reason = "long optie ontbreekt"
-                log_combo_evaluation(
-                    StrategyName.SHORT_CALL_SPREAD,
-                    desc,
-                    None,
-                    "reject",
-                    reason,
-                    legs=legs_info,
-                )
-                rejected_reasons.append(reason)
-                continue
-            legs = [
-                build_leg({**short_opt, "spot": spot}, "short"),
-                build_leg({**long_opt, "spot": spot}, "long"),
-            ]
-            proposal = StrategyProposal(legs=legs)
-            score, reasons = calculate_score(
-                StrategyName.SHORT_CALL_SPREAD, proposal, spot
-            )
-            if score is not None and passes_risk(proposal, min_rr):
-                proposals.append(proposal)
-                log_combo_evaluation(
-                    StrategyName.SHORT_CALL_SPREAD,
-                    desc,
-                    proposal.__dict__,
-                    "pass",
-                    "criteria",
-                    legs=legs,
-                )
-            else:
-                reason = "; ".join(reasons) if reasons else "risk/reward onvoldoende"
-                log_combo_evaluation(
-                    StrategyName.SHORT_CALL_SPREAD,
-                    desc,
-                    proposal.__dict__,
-                    "reject",
-                    reason,
-                    legs=legs,
-                )
-                if reasons:
-                    rejected_reasons.extend(reasons)
-                else:
-                    rejected_reasons.append("risk/reward onvoldoende")
-            if len(proposals) >= 5:
-                break
-    else:
-        rejected_reasons.append("ongeldige delta range")
-    proposals.sort(key=lambda p: p.score or 0, reverse=True)
-    if not proposals:
-        return [], sorted(set(rejected_reasons))
-    return proposals[:5], sorted(set(rejected_reasons))
+    return generate_short_vertical(
+        symbol,
+        option_chain,
+        config,
+        spot,
+        atr,
+        strategy_name=StrategyName.SHORT_CALL_SPREAD,
+        option_type="C",
+        delta_range_key="short_call_delta_range",
+    )
+
+
+__all__ = ["generate"]
+

--- a/tomic/strategies/short_put_spread.py
+++ b/tomic/strategies/short_put_spread.py
@@ -1,20 +1,10 @@
 from __future__ import annotations
+
 from typing import Any, Dict, List
-import pandas as pd
-from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
+
 from . import StrategyName
-from .utils import compute_dynamic_width
-from ..helpers.analysis.scoring import build_leg
-from ..analysis.scoring import calculate_score, passes_risk
-from ..logutils import log_combo_evaluation
-from ..utils import get_leg_right
-from ..strategy_candidates import (
-    StrategyProposal,
-    _build_strike_map,
-    _nearest_strike,
-    _find_option,
-)
-from ..strike_selector import _dte
+from ..strategy_candidates import StrategyProposal
+from .utils import generate_short_vertical
 
 
 def generate(
@@ -24,156 +14,19 @@ def generate(
     spot: float,
     atr: float,
 ) -> tuple[List[StrategyProposal], list[str]]:
-    rules = config.get("strike_to_strategy_config", {})
-    use_atr = bool(rules.get("use_ATR"))
-    if spot is None:
-        raise ValueError("spot price is required")
-    expiries = sorted({str(o.get("expiry")) for o in option_chain})
-    if not expiries:
-        return [], ["geen expiraties beschikbaar"]
-    strike_map = _build_strike_map(option_chain)
-    if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):
-        df_chain = pd.DataFrame(option_chain)
-        if spot > 0:
-            if "expiration" not in df_chain.columns and "expiry" in df_chain.columns:
-                df_chain["expiration"] = df_chain["expiry"]
-            df_chain = fill_missing_mid_with_parity(df_chain, spot=spot)
-            option_chain = df_chain.to_dict(orient="records")
-    proposals: List[StrategyProposal] = []
-    rejected_reasons: list[str] = []
-    min_rr = float(config.get("min_risk_reward", 0.0))
+    """Generate short put spread proposals using shared vertical logic."""
 
-    delta_range = rules.get("short_put_delta_range") or []
-    target_delta = rules.get("long_leg_distance_points")
-    atr_mult = rules.get("long_leg_atr_multiple")
-    dte_range = rules.get("dte_range")
-    if len(delta_range) == 2 and (target_delta is not None or atr_mult is not None):
-        for expiry in expiries:
-            if dte_range:
-                dte = _dte(expiry)
-                if dte is None or not (dte_range[0] <= dte <= dte_range[1]):
-                    continue
-            short_opt = None
-            for opt in option_chain:
-                if (
-                    str(opt.get("expiry")) == expiry
-                    and get_leg_right(opt) == "put"
-                    and opt.get("delta") is not None
-                    and delta_range[0] <= float(opt.get("delta")) <= delta_range[1]
-                ):
-                    short_opt = opt
-                    break
-            if not short_opt:
-                reason = "short optie ontbreekt"
-                desc = (
-                    f"target_delta {target_delta}" if target_delta is not None else f"atr_mult {atr_mult}"
-                )
-                log_combo_evaluation(
-                    StrategyName.SHORT_PUT_SPREAD,
-                    desc,
-                    None,
-                    "reject",
-                    reason,
-                    legs=[{"expiry": expiry}],
-                )
-                rejected_reasons.append(reason)
-                continue
-            width = compute_dynamic_width(
-                short_opt,
-                target_delta=target_delta,
-                atr_multiple=atr_mult,
-                atr=atr,
-                use_atr=use_atr,
-                option_chain=option_chain,
-                expiry=expiry,
-                option_type="P",
-            )
-            if width is None:
-                reason = "breedte niet berekend"
-                desc = (
-                    f"target_delta {target_delta}" if target_delta is not None else f"atr_mult {atr_mult}"
-                )
-                log_combo_evaluation(
-                    StrategyName.SHORT_PUT_SPREAD,
-                    desc,
-                    None,
-                    "reject",
-                    reason,
-                    legs=[
-                        {"expiry": expiry, "strike": short_opt.get("strike"), "type": "P", "position": -1}
-                    ],
-                )
-                rejected_reasons.append(reason)
-                continue
-            long_strike_target = float(short_opt.get("strike")) - width
-            long_strike = _nearest_strike(strike_map, expiry, "P", long_strike_target)
-            desc = f"short {short_opt.get('strike')} long {long_strike.matched}"
-            legs_info = [
-                {"expiry": expiry, "strike": short_opt.get("strike"), "type": "P", "position": -1},
-                {"expiry": expiry, "strike": long_strike.matched, "type": "P", "position": 1},
-            ]
-            if not long_strike.matched:
-                reason = "long strike niet gevonden"
-                log_combo_evaluation(
-                    StrategyName.SHORT_PUT_SPREAD,
-                    desc,
-                    None,
-                    "reject",
-                    reason,
-                    legs=legs_info,
-                )
-                rejected_reasons.append(reason)
-                continue
-            long_opt = _find_option(option_chain, expiry, long_strike.matched, "P")
-            if not long_opt:
-                reason = "long optie ontbreekt"
-                log_combo_evaluation(
-                    StrategyName.SHORT_PUT_SPREAD,
-                    desc,
-                    None,
-                    "reject",
-                    reason,
-                    legs=legs_info,
-                )
-                rejected_reasons.append(reason)
-                continue
-            legs = [
-                build_leg({**short_opt, "spot": spot}, "short"),
-                build_leg({**long_opt, "spot": spot}, "long"),
-            ]
-            proposal = StrategyProposal(legs=legs)
-            score, reasons = calculate_score(
-                StrategyName.SHORT_PUT_SPREAD, proposal, spot
-            )
-            if score is not None and passes_risk(proposal, min_rr):
-                proposals.append(proposal)
-                log_combo_evaluation(
-                    StrategyName.SHORT_PUT_SPREAD,
-                    desc,
-                    proposal.__dict__,
-                    "pass",
-                    "criteria",
-                    legs=legs,
-                )
-            else:
-                reason = "; ".join(reasons) if reasons else "risk/reward onvoldoende"
-                log_combo_evaluation(
-                    StrategyName.SHORT_PUT_SPREAD,
-                    desc,
-                    proposal.__dict__,
-                    "reject",
-                    reason,
-                    legs=legs,
-                )
-                if reasons:
-                    rejected_reasons.extend(reasons)
-                else:
-                    rejected_reasons.append("risk/reward onvoldoende")
-            if len(proposals) >= 5:
-                break
-    else:
-        rejected_reasons.append("ongeldige delta range")
-    proposals.sort(key=lambda p: p.score or 0, reverse=True)
-    if not proposals:
-        return [], sorted(set(rejected_reasons))
-    return proposals[:5], sorted(set(rejected_reasons))
+    return generate_short_vertical(
+        symbol,
+        option_chain,
+        config,
+        spot,
+        atr,
+        strategy_name=StrategyName.SHORT_PUT_SPREAD,
+        option_type="P",
+        delta_range_key="short_put_delta_range",
+    )
+
+
+__all__ = ["generate"]
+

--- a/tomic/strategies/utils.py
+++ b/tomic/strategies/utils.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import math
 from typing import Sequence, Any, Dict, List, Mapping
 
+import pandas as pd
+from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
 from tomic.helpers.dateutils import dte_between_dates
 
 from ..utils import normalize_right, get_leg_right, today
 from ..logutils import logger
+from ..strike_selector import _dte
 
 
 def validate_width_list(widths: Sequence[Any] | Mapping[str, Any] | float | int | None, key: str) -> Sequence[Any]:
@@ -143,8 +146,232 @@ def compute_dynamic_width(
     return None
 
 
+def prepare_option_chain(option_chain: List[Dict[str, Any]], spot: float) -> List[Dict[str, Any]]:
+    """Return ``option_chain`` as list of dicts with parity-filled mids."""
+
+    if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):
+        df_chain = pd.DataFrame(option_chain)
+        if spot > 0:
+            if "expiration" not in df_chain.columns and "expiry" in df_chain.columns:
+                df_chain["expiration"] = df_chain["expiry"]
+            df_chain = fill_missing_mid_with_parity(df_chain, spot=spot)
+            option_chain = df_chain.to_dict(orient="records")
+    return option_chain
+
+
+def filter_expiries_by_dte(
+    expiries: Sequence[str], dte_range: Sequence[int] | None
+) -> List[str]:
+    """Return expiries whose DTE lies within ``dte_range``."""
+
+    if not dte_range:
+        return list(expiries)
+    filtered: List[str] = []
+    for exp in expiries:
+        dte = _dte(exp)
+        if dte is not None and dte_range[0] <= dte <= dte_range[1]:
+            filtered.append(exp)
+    return filtered
+
+
+def generate_short_vertical(
+    symbol: str,
+    option_chain: List[Dict[str, Any]],
+    config: Dict[str, Any],
+    spot: float,
+    atr: float,
+    *,
+    strategy_name: "StrategyName",
+    option_type: str,
+    delta_range_key: str,
+) -> tuple[List["StrategyProposal"], list[str]]:
+    """Shared generator for short vertical call and put spreads."""
+
+    from ..helpers.analysis.scoring import build_leg
+    from ..analysis.scoring import calculate_score, passes_risk
+    from ..logutils import log_combo_evaluation
+    from ..utils import get_leg_right
+    from ..strategy_candidates import (
+        StrategyProposal,
+        _build_strike_map,
+        _nearest_strike,
+        _find_option,
+    )
+
+    rules = config.get("strike_to_strategy_config", {})
+    use_atr = bool(rules.get("use_ATR"))
+    if spot is None:
+        raise ValueError("spot price is required")
+
+    option_chain = prepare_option_chain(option_chain, spot)
+    expiries = sorted({str(o.get("expiry")) for o in option_chain})
+    if not expiries:
+        return [], ["geen expiraties beschikbaar"]
+    strike_map = _build_strike_map(option_chain)
+
+    proposals: List[StrategyProposal] = []
+    rejected_reasons: list[str] = []
+    min_rr = float(config.get("min_risk_reward", 0.0))
+
+    delta_range = rules.get(delta_range_key) or []
+    target_delta = rules.get("long_leg_distance_points")
+    atr_mult = rules.get("long_leg_atr_multiple")
+    dte_range = rules.get("dte_range")
+
+    expiries = filter_expiries_by_dte(expiries, dte_range)
+
+    leg_right = "call" if option_type == "C" else "put"
+
+    if len(delta_range) == 2 and (target_delta is not None or atr_mult is not None):
+        for expiry in expiries:
+            short_opt = None
+            for opt in option_chain:
+                if (
+                    str(opt.get("expiry")) == expiry
+                    and get_leg_right(opt) == leg_right
+                    and opt.get("delta") is not None
+                    and delta_range[0] <= float(opt.get("delta")) <= delta_range[1]
+                ):
+                    short_opt = opt
+                    break
+            if not short_opt:
+                reason = "short optie ontbreekt"
+                desc = (
+                    f"target_delta {target_delta}" if target_delta is not None else f"atr_mult {atr_mult}"
+                )
+                log_combo_evaluation(
+                    strategy_name,
+                    desc,
+                    None,
+                    "reject",
+                    reason,
+                    legs=[{"expiry": expiry}],
+                )
+                rejected_reasons.append(reason)
+                continue
+            width = compute_dynamic_width(
+                short_opt,
+                target_delta=target_delta,
+                atr_multiple=atr_mult,
+                atr=atr,
+                use_atr=use_atr,
+                option_chain=option_chain,
+                expiry=expiry,
+                option_type=option_type,
+            )
+            if width is None:
+                reason = "breedte niet berekend"
+                desc = (
+                    f"target_delta {target_delta}" if target_delta is not None else f"atr_mult {atr_mult}"
+                )
+                log_combo_evaluation(
+                    strategy_name,
+                    desc,
+                    None,
+                    "reject",
+                    reason,
+                    legs=[
+                        {
+                            "expiry": expiry,
+                            "strike": short_opt.get("strike"),
+                            "type": option_type,
+                            "position": -1,
+                        }
+                    ],
+                )
+                rejected_reasons.append(reason)
+                continue
+            if option_type == "C":
+                long_strike_target = float(short_opt.get("strike")) + width
+            else:
+                long_strike_target = float(short_opt.get("strike")) - width
+            long_strike = _nearest_strike(strike_map, expiry, option_type, long_strike_target)
+            desc = f"short {short_opt.get('strike')} long {long_strike.matched}"
+            legs_info = [
+                {
+                    "expiry": expiry,
+                    "strike": short_opt.get("strike"),
+                    "type": option_type,
+                    "position": -1,
+                },
+                {
+                    "expiry": expiry,
+                    "strike": long_strike.matched,
+                    "type": option_type,
+                    "position": 1,
+                },
+            ]
+            if not long_strike.matched:
+                reason = "long strike niet gevonden"
+                log_combo_evaluation(
+                    strategy_name,
+                    desc,
+                    None,
+                    "reject",
+                    reason,
+                    legs=legs_info,
+                )
+                rejected_reasons.append(reason)
+                continue
+            long_opt = _find_option(option_chain, expiry, long_strike.matched, option_type)
+            if not long_opt:
+                reason = "long optie ontbreekt"
+                log_combo_evaluation(
+                    strategy_name,
+                    desc,
+                    None,
+                    "reject",
+                    reason,
+                    legs=legs_info,
+                )
+                rejected_reasons.append(reason)
+                continue
+            legs = [
+                build_leg({**short_opt, "spot": spot}, "short"),
+                build_leg({**long_opt, "spot": spot}, "long"),
+            ]
+            proposal = StrategyProposal(legs=legs)
+            score, reasons = calculate_score(strategy_name, proposal, spot)
+            if score is not None and passes_risk(proposal, min_rr):
+                proposals.append(proposal)
+                log_combo_evaluation(
+                    strategy_name,
+                    desc,
+                    proposal.__dict__,
+                    "pass",
+                    "criteria",
+                    legs=legs,
+                )
+            else:
+                reason = "; ".join(reasons) if reasons else "risk/reward onvoldoende"
+                log_combo_evaluation(
+                    strategy_name,
+                    desc,
+                    proposal.__dict__,
+                    "reject",
+                    reason,
+                    legs=legs,
+                )
+                if reasons:
+                    rejected_reasons.extend(reasons)
+                else:
+                    rejected_reasons.append("risk/reward onvoldoende")
+            if len(proposals) >= 5:
+                break
+    else:
+        rejected_reasons.append("ongeldige delta range")
+
+    proposals.sort(key=lambda p: p.score or 0, reverse=True)
+    if not proposals:
+        return [], sorted(set(rejected_reasons))
+    return proposals[:5], sorted(set(rejected_reasons))
+
+
 __all__ = [
     "validate_width_list",
     "compute_dynamic_width",
+    "prepare_option_chain",
+    "filter_expiries_by_dte",
+    "generate_short_vertical",
 ]
 


### PR DESCRIPTION
## Summary
- add prepare_option_chain and filter_expiries_by_dte helpers
- centralize short vertical spread generation
- use new helpers in ratio_spread and short vertical strategies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b949ee2bfc832ea56f8d4728e29278