### PR TITLE
refactor: centralize Black-Scholes estimates

### DIFF
--- a/tomic/helpers/bs_utils.py
+++ b/tomic/helpers/bs_utils.py
@@ -1,0 +1,51 @@
+"""Black-Scholes helper utilities."""
+from __future__ import annotations
+
+import math
+
+from ..bs_calculator import black_scholes
+from .dateutils import dte_between_dates
+from ..config import get as cfg_get
+from ..utils import today
+
+
+def estimate_price_delta(leg: dict) -> tuple[float, float]:
+    """Estimate model price and delta for a leg using Black-Scholes.
+
+    Parameters
+    ----------
+    leg: dict
+        Option leg containing ``type``/``right``, ``strike``, ``spot`` or
+        underlying price, implied volatility and expiry information.
+
+    Returns
+    -------
+    tuple[float, float]
+        A tuple of ``(price, delta)``.
+    """
+    opt_type = (leg.get("type") or leg.get("right") or "").upper()[0]
+    strike = float(leg.get("strike"))
+    spot = float(
+        leg.get("spot")
+        or leg.get("underlying_price")
+        or leg.get("underlying")
+    )
+    iv = float(leg.get("iv"))
+    exp = leg.get("expiry") or leg.get("expiration")
+    if not exp:
+        raise ValueError("missing expiry")
+    dte = dte_between_dates(today(), str(exp))
+    if dte is None or dte <= 0 or iv <= 0 or spot <= 0:
+        raise ValueError("invalid parameters")
+    r = float(cfg_get("INTEREST_RATE", 0.05))
+    price = black_scholes(opt_type, spot, strike, dte, iv, r=r, q=0.0)
+    T = dte / 365.0
+    d1 = (
+        math.log(spot / strike) + (r - 0.0 + 0.5 * iv * iv) * T
+    ) / (iv * math.sqrt(T))
+    nd1 = 0.5 * (1.0 + math.erf(d1 / math.sqrt(2.0)))
+    delta = nd1 if opt_type == "C" else nd1 - 1
+    return price, delta
+
+
+__all__ = ["estimate_price_delta"]


### PR DESCRIPTION
## Summary
- add `estimate_price_delta` helper for shared Black-Scholes price and delta calculation
- use helper in strategy scoring to fill missing model data
- streamline leg building by reusing Black-Scholes helper

## Testing
- `pytest tests/analysis/test_strategy_scoring.py::test_strategy_scoring_applies_weights -q`
- `pytest tests/cli/test_bs_calculator.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b95fd0c730832e9ff1a5c2a9e19dd7