### PR TITLE
Refactor IV helpers with shared numeric validation

### DIFF
--- a/tomic/providers/polygon_iv.py
+++ b/tomic/providers/polygon_iv.py
@@ -51,9 +51,15 @@ def _rolling_hv(closes: list[float], window: int) -> list[float]:
     return series
 
 
-def _iv_rank(value: float, series: list[float]) -> float | None:
+def _valid_numbers(series: list[float]) -> list[float] | None:
+    """Return numeric values from ``series`` or ``None`` when absent."""
     nums = [s for s in series if isinstance(s, (int, float))]
-    if not nums:
+    return nums or None
+
+
+def _iv_rank(value: float, series: list[float]) -> float | None:
+    nums = _valid_numbers(series)
+    if nums is None:
         return None
     lo = min(nums)
     hi = max(nums)
@@ -63,8 +69,8 @@ def _iv_rank(value: float, series: list[float]) -> float | None:
 
 
 def _iv_percentile(value: float, series: list[float]) -> float | None:
-    nums = [s for s in series if isinstance(s, (int, float))]
-    if not nums:
+    nums = _valid_numbers(series)
+    if nums is None:
         return None
     count = sum(1 for hv in nums if hv < value)
     return count / len(nums)


### PR DESCRIPTION
## Summary
- add `_valid_numbers` helper for series filtering
- reuse `_valid_numbers` inside `_iv_rank` and `_iv_percentile`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b96171c34c832eb9cdae4427929db6