### PR TITLE
Use prepare_option_chain in option strategies

### DIFF
--- a/tomic/strategies/atm_iron_butterfly.py
+++ b/tomic/strategies/atm_iron_butterfly.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 from typing import Any, Dict, List
-import pandas as pd
-from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
 from . import StrategyName
-from .utils import compute_dynamic_width
+from .utils import compute_dynamic_width, prepare_option_chain
 from ..helpers.analysis.scoring import build_leg
 from ..analysis.scoring import calculate_score, passes_risk
 from ..logutils import log_combo_evaluation
@@ -30,14 +28,8 @@ def generate(
     expiries = sorted({str(o.get("expiry")) for o in option_chain})
     if not expiries:
         return [], ["geen expiraties beschikbaar"]
+    option_chain = prepare_option_chain(option_chain, spot)
     strike_map = _build_strike_map(option_chain)
-    if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):
-        df_chain = pd.DataFrame(option_chain)
-        if spot > 0:
-            if "expiration" not in df_chain.columns and "expiry" in df_chain.columns:
-                df_chain["expiration"] = df_chain["expiry"]
-            df_chain = fill_missing_mid_with_parity(df_chain, spot=spot)
-            option_chain = df_chain.to_dict(orient="records")
     proposals: List[StrategyProposal] = []
     rejected_reasons: list[str] = []
     min_rr = float(config.get("min_risk_reward", 0.0))

--- a/tomic/strategies/backspread_put.py
+++ b/tomic/strategies/backspread_put.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 from typing import Any, Dict, List
-import pandas as pd
-from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
 from . import StrategyName
-from .utils import compute_dynamic_width
+from .utils import compute_dynamic_width, prepare_option_chain
 from ..helpers.analysis.scoring import build_leg
 from ..analysis.scoring import calculate_score, passes_risk
 from ..logutils import log_combo_evaluation
@@ -33,14 +31,8 @@ def generate(
     expiries = sorted({str(o.get("expiry")) for o in option_chain})
     if not expiries:
         return [], ["geen expiraties beschikbaar"]
+    option_chain = prepare_option_chain(option_chain, spot)
     strike_map = _build_strike_map(option_chain)
-    if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):
-        df_chain = pd.DataFrame(option_chain)
-        if spot > 0:
-            if "expiration" not in df_chain.columns and "expiry" in df_chain.columns:
-                df_chain["expiration"] = df_chain["expiry"]
-            df_chain = fill_missing_mid_with_parity(df_chain, spot=spot)
-            option_chain = df_chain.to_dict(orient="records")
     proposals: List[StrategyProposal] = []
     rejected_reasons: list[str] = []
     min_rr = float(config.get("min_risk_reward", 0.0))

--- a/tomic/strategies/calendar.py
+++ b/tomic/strategies/calendar.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 # Calendar strategy generator supporting calls and puts.
-import pandas as pd
-from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
 from . import StrategyName
+from .utils import prepare_option_chain
 from ..helpers.analysis.scoring import build_leg
 from ..analysis.scoring import calculate_score, passes_risk
 from ..logutils import log_combo_evaluation
@@ -32,13 +31,7 @@ def generate(
         return [], ["geen expiraties beschikbaar"]
     if spot is None:
         raise ValueError("spot price is required")
-    if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):
-        df_chain = pd.DataFrame(option_chain)
-        if spot > 0:
-            if "expiration" not in df_chain.columns and "expiry" in df_chain.columns:
-                df_chain["expiration"] = df_chain["expiry"]
-            df_chain = fill_missing_mid_with_parity(df_chain, spot=spot)
-            option_chain = df_chain.to_dict(orient="records")
+    option_chain = prepare_option_chain(option_chain, spot)
 
     proposals: List[StrategyProposal] = []
     rejected_reasons: list[str] = []

--- a/tomic/strategies/naked_put.py
+++ b/tomic/strategies/naked_put.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 from typing import Any, Dict, List
-import pandas as pd
-from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
 from . import StrategyName
+from .utils import prepare_option_chain
 from ..helpers.analysis.scoring import build_leg
 from ..analysis.scoring import calculate_score, passes_risk
 from ..logutils import log_combo_evaluation
@@ -27,13 +26,7 @@ def generate(
     expiries = sorted({str(o.get("expiry")) for o in option_chain})
     if not expiries:
         return [], ["geen expiraties beschikbaar"]
-    if hasattr(pd, "DataFrame") and not isinstance(pd.DataFrame, type(object)):
-        df_chain = pd.DataFrame(option_chain)
-        if spot > 0:
-            if "expiration" not in df_chain.columns and "expiry" in df_chain.columns:
-                df_chain["expiration"] = df_chain["expiry"]
-            df_chain = fill_missing_mid_with_parity(df_chain, spot=spot)
-            option_chain = df_chain.to_dict(orient="records")
+    option_chain = prepare_option_chain(option_chain, spot)
     proposals: List[StrategyProposal] = []
     rejected_reasons: list[str] = []
     min_rr = float(config.get("min_risk_reward", 0.0))


### PR DESCRIPTION
## Summary
- Replace manual parity handling with `prepare_option_chain`
- Remove unused imports in strategy modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b9712e0d20832eaf662f13a3a0ec9a