### PR TITLE
Refactor DTE filtering across strategies

### DIFF
--- a/tomic/strategies/atm_iron_butterfly.py
+++ b/tomic/strategies/atm_iron_butterfly.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Any, Dict, List
 from . import StrategyName
-from .utils import compute_dynamic_width, prepare_option_chain
+from .utils import compute_dynamic_width, prepare_option_chain, filter_expiries_by_dte
 from ..helpers.analysis.scoring import build_leg
 from ..analysis.scoring import calculate_score, passes_risk
 from ..logutils import log_combo_evaluation
@@ -11,7 +11,6 @@ from ..strategy_candidates import (
     _nearest_strike,
     _find_option,
 )
-from ..strike_selector import _dte
 
 
 def generate(
@@ -37,11 +36,8 @@ def generate(
     centers = rules.get("center_strike_relative_to_spot", [0])
     sigma_mult = float(rules.get("wing_sigma_multiple", 1.0))
     dte_range = rules.get("dte_range")
+    expiries = filter_expiries_by_dte(expiries, dte_range)
     for expiry in expiries:
-        if dte_range:
-            dte = _dte(expiry)
-            if dte is None or not (dte_range[0] <= dte <= dte_range[1]):
-                continue
         for c_off in centers:
             center = spot + (c_off * atr if use_atr else c_off)
             center = _nearest_strike(strike_map, expiry, "C", center).matched

--- a/tomic/strategies/backspread_put.py
+++ b/tomic/strategies/backspread_put.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Any, Dict, List
 from . import StrategyName
-from .utils import compute_dynamic_width, prepare_option_chain
+from .utils import compute_dynamic_width, prepare_option_chain, filter_expiries_by_dte
 from ..helpers.analysis.scoring import build_leg
 from ..analysis.scoring import calculate_score, passes_risk
 from ..logutils import log_combo_evaluation
@@ -14,7 +14,6 @@ from ..strategy_candidates import (
     _validate_ratio,
     select_expiry_pairs,
 )
-from ..strike_selector import _dte
 
 
 def generate(
@@ -42,13 +41,7 @@ def generate(
     atr_mult = rules.get("long_leg_atr_multiple")
     min_gap = int(rules.get("expiry_gap_min_days", 0))
     dte_range = rules.get("dte_range")
-    filtered_expiries = []
-    for exp in expiries:
-        if dte_range:
-            dte = _dte(exp)
-            if dte is None or not (dte_range[0] <= dte <= dte_range[1]):
-                continue
-        filtered_expiries.append(exp)
+    filtered_expiries = filter_expiries_by_dte(expiries, dte_range)
     pairs = select_expiry_pairs(filtered_expiries, min_gap)
     if len(delta_range) == 2 and (target_delta is not None or atr_mult is not None):
         for near, far in pairs[:3]:

--- a/tomic/strategies/calendar.py
+++ b/tomic/strategies/calendar.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List
 
 # Calendar strategy generator supporting calls and puts.
 from . import StrategyName
-from .utils import prepare_option_chain
+from .utils import prepare_option_chain, filter_expiries_by_dte
 from ..helpers.analysis.scoring import build_leg
 from ..analysis.scoring import calculate_score, passes_risk
 from ..logutils import log_combo_evaluation
@@ -14,7 +14,6 @@ from ..strategy_candidates import (
     _options_by_strike,
     select_expiry_pairs,
 )
-from ..strike_selector import _dte
 
 
 def generate(
@@ -64,11 +63,7 @@ def generate(
             for cand in candidate_strikes:
                 valid_exp = sorted(by_strike[cand])
                 if dte_range:
-                    valid_exp = [
-                        e
-                        for e in valid_exp
-                        if (d := _dte(e)) is not None and dte_range[0] <= d <= dte_range[1]
-                    ]
+                    valid_exp = filter_expiries_by_dte(valid_exp, dte_range)
                 pairs = select_expiry_pairs(valid_exp, min_gap)
                 desc_cand = f"{option_type} strike {cand}"
                 if not pairs:

--- a/tomic/strategies/iron_condor.py
+++ b/tomic/strategies/iron_condor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Any, Dict, List
 from itertools import islice
 from . import StrategyName
-from .utils import compute_dynamic_width, prepare_option_chain
+from .utils import compute_dynamic_width, prepare_option_chain, filter_expiries_by_dte
 from ..helpers.analysis.scoring import build_leg
 from ..analysis.scoring import calculate_score, passes_risk
 from ..logutils import log_combo_evaluation
@@ -13,7 +13,6 @@ from ..strategy_candidates import (
     _nearest_strike,
     _find_option,
 )
-from ..strike_selector import _dte
 
 
 def generate(
@@ -40,12 +39,9 @@ def generate(
     put_range = rules.get("short_put_delta_range") or []
     sigma_mult = float(rules.get("wing_sigma_multiple", 1.0))
     dte_range = rules.get("dte_range")
+    expiries = filter_expiries_by_dte(expiries, dte_range)
 
     for expiry in expiries:
-        if dte_range:
-            dte = _dte(expiry)
-            if dte is None or not (dte_range[0] <= dte <= dte_range[1]):
-                continue
         shorts_c = [
             o
             for o in option_chain

--- a/tomic/strategies/naked_put.py
+++ b/tomic/strategies/naked_put.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Any, Dict, List
 from . import StrategyName
-from .utils import prepare_option_chain
+from .utils import prepare_option_chain, filter_expiries_by_dte
 from ..helpers.analysis.scoring import build_leg
 from ..analysis.scoring import calculate_score, passes_risk
 from ..logutils import log_combo_evaluation
@@ -9,7 +9,6 @@ from ..utils import get_leg_right
 from ..strategy_candidates import (
     StrategyProposal,
 )
-from ..strike_selector import _dte
 
 
 def generate(
@@ -33,12 +32,9 @@ def generate(
 
     delta_range = rules.get("short_put_delta_range") or []
     dte_range = rules.get("dte_range")
+    expiries = filter_expiries_by_dte(expiries, dte_range)
     if len(delta_range) == 2:
         for expiry in expiries:
-            if dte_range:
-                dte = _dte(expiry)
-                if dte is None or not (dte_range[0] <= dte <= dte_range[1]):
-                    continue
             for opt in option_chain:
                 if (
                     str(opt.get("expiry")) == expiry


### PR DESCRIPTION
## Summary
- Use shared `filter_expiries_by_dte` helper for expiry selection
- Drop local DTE calculations and duplicate checks
- Ensure consistent DTE filtering in multiple strategies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b974b790b0832eaa3cd4c1a21fba85