### PR TITLE
refactor: import parse_date directly

### DIFF
--- a/tomic/analysis/metrics.py
+++ b/tomic/analysis/metrics.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Iterable, Sequence
 import math
 import statistics
 
-from tomic.analysis.strategy import parse_date
+from tomic.helpers.dateutils import parse_date
 from tomic.helpers.account import _fmt_money
 
 

--- a/tomic/analysis/strategy.py
+++ b/tomic/analysis/strategy.py
@@ -12,12 +12,7 @@ from tomic.utils import today, get_leg_right
 from tomic.analysis.alerts import check_entry_conditions, generate_risk_alerts
 from tomic.analysis.greeks import compute_portfolio_greeks
 from tomic.logutils import logger
-from tomic.helpers.dateutils import parse_date as _parse_date
-
-
-def parse_date(date_str: str) -> Optional[date]:
-    """Parse ``date_str`` using :func:`tomic.helpers.dateutils.parse_date`."""
-    return _parse_date(date_str)
+from tomic.helpers.dateutils import parse_date
 
 
 # Strategy detection helpers -------------------------------------------------

--- a/tomic/strategy_candidates.py
+++ b/tomic/strategy_candidates.py
@@ -6,7 +6,7 @@ from datetime import date, datetime
 import math
 
 from .analysis.scoring import calculate_score, calculate_breakevens
-from .analysis.strategy import parse_date
+from .helpers.dateutils import parse_date
 from .utils import (
     get_option_mid_price,
     normalize_right,


### PR DESCRIPTION
## Summary
- remove parse_date wrapper from strategy utilities
- import parse_date directly in analysis and strategy candidates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b99939e2dc832ead20d77e98057daf