### PR TITLE
feat: expose latest close date

### DIFF
--- a/tests/helpers/test_price_utils.py
+++ b/tests/helpers/test_price_utils.py
@@ -17,3 +17,6 @@ def test_load_latest_close_non_positive(monkeypatch, tmp_path):
     assert price is None
     assert date == "2024-01-01"
 
+    date_only = price_utils._load_latest_close("AAA", return_date_only=True)
+    assert date_only == "2024-01-01"
+

--- a/tomic/cli/compute_volstats.py
+++ b/tomic/cli/compute_volstats.py
@@ -12,7 +12,8 @@ from pathlib import Path
 from tomic.journal.utils import update_json_file
 from tomic.analysis.metrics import historical_volatility
 from tomic.api.market_client import TermStructureClient, start_app, await_market_data
-from tomic.utils import latest_close_date, load_price_history
+from tomic.utils import load_price_history
+from tomic.helpers.price_utils import _load_latest_close
 
 
 def _get_closes(symbol: str) -> list[float]:
@@ -102,7 +103,9 @@ def main(argv: List[str] | None = None) -> None:
         hv90 = historical_volatility(closes, window=90)
         hv252 = historical_volatility(closes, window=252)
         iv = fetch_iv30d(sym)
-        date_str = latest_close_date(sym) or datetime.now().strftime("%Y-%m-%d")
+        date_str = _load_latest_close(sym, return_date_only=True) or datetime.now().strftime(
+            "%Y-%m-%d"
+        )
         hv_series = rolling_hv(closes, 30)
         scaled_iv = iv * 100 if iv is not None else None
         rank = iv_rank(scaled_iv or 0.0, hv_series) if scaled_iv is not None else None

--- a/tomic/cli/fetch_iv_polygon.py
+++ b/tomic/cli/fetch_iv_polygon.py
@@ -11,7 +11,7 @@ from tomic.config import get as cfg_get
 from tomic.logutils import logger, setup_logging
 from tomic.journal.utils import load_json, update_json_file
 from tomic.providers.polygon_iv import fetch_polygon_iv30d
-from tomic.utils import latest_close_date
+from tomic.helpers.price_utils import _load_latest_close
 
 
 def main(argv: List[str] | None = None) -> None:
@@ -34,7 +34,9 @@ def main(argv: List[str] | None = None) -> None:
         if max_syms is not None and processed >= max_syms:
             break
         metrics = fetch_polygon_iv30d(sym)
-        date_str = latest_close_date(sym) or datetime.now().strftime("%Y-%m-%d")
+        date_str = _load_latest_close(sym, return_date_only=True) or datetime.now().strftime(
+            "%Y-%m-%d"
+        )
         if metrics is None:
             logger.warning(f"No contracts found for symbol {sym}")
             continue

--- a/tomic/helpers/price_utils.py
+++ b/tomic/helpers/price_utils.py
@@ -5,8 +5,20 @@ from tomic.logutils import logger
 from tomic.utils import load_price_history
 
 
-def _load_latest_close(symbol: str) -> tuple[float | None, str | None]:
-    """Return the most recent close and its date for ``symbol``."""
+def _load_latest_close(
+    symbol: str, *, return_date_only: bool = False
+) -> tuple[float | None, str | None] | str | None:
+    """Return the most recent close and its date for ``symbol``.
+
+    Parameters
+    ----------
+    symbol:
+        The ticker symbol to look up.
+    return_date_only:
+        When ``True`` only the close date is returned.  Otherwise a tuple of
+        ``(price, date)`` is returned as before.
+    """
+
     logger.debug(f"Loading close price for {symbol}")
     data = load_price_history(symbol)
     if data:
@@ -18,12 +30,12 @@ def _load_latest_close(symbol: str) -> tuple[float | None, str | None]:
                 logger.debug(
                     f"Ignoring non-positive close for {symbol} on {date_str}: {price}"
                 )
-                return None, date_str
+                return date_str if return_date_only else (None, date_str)
             logger.debug(f"Using last close for {symbol} on {date_str}: {price}")
-            return price, date_str
+            return date_str if return_date_only else (price, date_str)
         except Exception:
-            return None, None
-    return None, None
+            return None if return_date_only else (None, None)
+    return None if return_date_only else (None, None)
 
 
 __all__ = ["_load_latest_close"]

--- a/tomic/utils.py
+++ b/tomic/utils.py
@@ -109,10 +109,9 @@ def load_price_history(symbol: str) -> list[dict]:
 def latest_close_date(symbol: str) -> str | None:
     """Return the most recent close date for ``symbol`` from price history."""
 
-    data = load_price_history(symbol)
-    if data:
-        return str(data[-1].get("date"))
-    return None
+    from tomic.helpers.price_utils import _load_latest_close
+
+    return _load_latest_close(symbol, return_date_only=True)
 
 
 def get_option_mid_price(option: dict) -> tuple[float | None, bool]:


### PR DESCRIPTION
## Summary
- allow _load_latest_close to optionally return only the close date
- delegate utils.latest_close_date to _load_latest_close
- update volstats and polygon IV tools to use new helper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b9e81f20a8832e82982922e358d621