### PR TITLE
refactor DTE filtering helper

### DIFF
--- a/tests/analysis/test_strike_selector.py
+++ b/tests/analysis/test_strike_selector.py
@@ -2,6 +2,7 @@ from importlib import reload
 
 from tomic import strike_selector as ss
 from tomic.criteria import StrikeCriteria, load_criteria
+from tomic.helpers.dateutils import filter_by_dte
 
 
 def test_selector_filters(monkeypatch):
@@ -99,3 +100,15 @@ def test_filter_by_expiry_none(monkeypatch):
     ]
     res = selector.select(opts, dte_range=(20, 40))
     assert res == []
+
+
+def test_filter_by_dte_helper(monkeypatch):
+    monkeypatch.setenv("TOMIC_TODAY", "2024-06-01")
+    opts = [
+        {"expiry": "20240614"},
+        {"expiry": "20240621"},
+        {"expiry": "20240719"},
+    ]
+    res = filter_by_dte(opts, lambda o: o["expiry"], (10, 20))
+    expiries = {o["expiry"] for o in res}
+    assert expiries == {"20240614", "20240621"}

--- a/tomic/analysis/proposal_engine.py
+++ b/tomic/analysis/proposal_engine.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Iterable, List, Optional
 from tomic.analysis.greeks import compute_greeks_by_symbol
 from tomic.analysis.strategy import heuristic_risk_metrics
 from tomic.helpers.csv_utils import parse_euro_float
-from tomic.helpers.dateutils import dte_between_dates
+from tomic.helpers.dateutils import filter_by_dte
 from tomic.journal.utils import load_json
 from tomic.logutils import logger
 from tomic.metrics import calculate_margin, estimate_scenario_profit
@@ -174,14 +174,7 @@ def _filter_chain_by_dte(chain: List[Leg], strategy: str) -> List[Leg]:
     dte_range = rules.get("dte_range")
     if not dte_range:
         return chain
-    min_dte, max_dte = dte_range
-    today_date = today()
-    filtered = [
-        leg
-        for leg in chain
-        if (d := dte_between_dates(today_date, leg.expiry)) is not None
-        and min_dte <= d <= max_dte
-    ]
+    filtered = filter_by_dte(chain, lambda leg: leg.expiry, dte_range)
     return filtered or chain
 
 

--- a/tomic/helpers/dateutils.py
+++ b/tomic/helpers/dateutils.py
@@ -1,10 +1,11 @@
 from datetime import datetime, date
-from typing import Optional, Union
+from typing import Callable, Iterable, List, Optional, Tuple, TypeVar, Union
 
 from tomic.utils import today
 
 
 DateLike = Union[str, date]
+T = TypeVar("T")
 
 
 def parse_date(d: DateLike) -> Optional[date]:
@@ -31,4 +32,21 @@ def dte_between_dates(start: DateLike, end: DateLike) -> Optional[int]:
     if s is None or e is None:
         return None
     return (e - s).days
+
+
+def filter_by_dte(
+    iterable: Iterable[T],
+    key_func: Callable[[T], DateLike],
+    dte_range: Tuple[int, int],
+) -> List[T]:
+    """Return items from ``iterable`` with DTE within ``dte_range``."""
+
+    min_dte, max_dte = dte_range
+    today_date = today()
+    selected: List[T] = []
+    for item in iterable:
+        d = dte_between_dates(today_date, key_func(item))
+        if d is not None and min_dte <= d <= max_dte:
+            selected.append(item)
+    return selected
 

--- a/tomic/strategies/utils.py
+++ b/tomic/strategies/utils.py
@@ -7,11 +7,10 @@ from typing import Sequence, Any, Dict, List, Mapping
 
 import pandas as pd
 from tomic.helpers.put_call_parity import fill_missing_mid_with_parity
-from tomic.helpers.dateutils import dte_between_dates
+from tomic.helpers.dateutils import dte_between_dates, filter_by_dte
 
 from ..utils import normalize_right, get_leg_right, today
 from ..logutils import logger
-from ..strike_selector import _dte
 
 
 MAX_PROPOSALS = 5
@@ -204,12 +203,7 @@ def filter_expiries_by_dte(
 
     if not dte_range:
         return list(expiries)
-    filtered: List[str] = []
-    for exp in expiries:
-        dte = _dte(exp)
-        if dte is not None and dte_range[0] <= dte <= dte_range[1]:
-            filtered.append(exp)
-    return filtered
+    return filter_by_dte(expiries, lambda exp: exp, (dte_range[0], dte_range[1]))
 
 
 def generate_short_vertical(


### PR DESCRIPTION
## Summary
- add generic `filter_by_dte` helper for filtering collections by days-to-expiry
- simplify strike and proposal filtering to reuse `filter_by_dte`
- update tests for new helper

## Testing
- `pytest tests/analysis/test_strike_selector.py tests/analysis/test_proposal_engine.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b9eab96018832eb98c9f7af4fc009f