### PR TITLE
Refactor expiry extraction to use unified helper

### DIFF
--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -27,7 +27,9 @@ def test_extract_weeklies(monkeypatch):
     importlib.reload(utils)
 
     expiries = ["20240531", "20240607", "20240614", "20240621", "20240628"]
-    assert utils.extract_weeklies(expiries, count=2) == ["20240607", "20240614"]
+    assert utils.extract_expiries(
+        expiries, count=2, predicate=utils._is_weekly
+    ) == ["20240607", "20240614"]
 
 
 def test_extract_monthlies(monkeypatch):
@@ -35,7 +37,9 @@ def test_extract_monthlies(monkeypatch):
     importlib.reload(utils)
 
     expiries = ["20240607", "20240621", "20240719", "20240816"]
-    assert utils.extract_monthlies(expiries, count=2) == ["20240621", "20240719"]
+    assert utils.extract_expiries(
+        expiries, count=2, predicate=utils._is_third_friday
+    ) == ["20240621", "20240719"]
 
 
 def test_get_option_mid_price_bid_ask():

--- a/tomic/api/market_client.py
+++ b/tomic/api/market_client.py
@@ -32,7 +32,7 @@ from tomic.config import get as cfg_get
 from .client_registry import ACTIVE_CLIENT_IDS
 from tomic.logutils import log_result, logger
 from tomic.models import OptionContract
-from tomic.utils import extract_monthlies, extract_weeklies, today
+from tomic.utils import extract_expiries, _is_weekly, _is_third_friday, today
 from .historical_iv import fetch_historical_option_data
 
 try:  # pragma: no cover - optional dependency during tests
@@ -900,8 +900,12 @@ class OptionChainClient(MarketClient):
 
         reg_count = int(cfg_get("AMOUNT_REGULARS", 3))
         week_count = int(cfg_get("AMOUNT_WEEKLIES", 4))
-        monthlies = extract_monthlies(exp_list, count=reg_count)
-        weeklies = extract_weeklies(exp_list, count=week_count)
+        monthlies = extract_expiries(
+            exp_list, count=reg_count, predicate=_is_third_friday
+        )
+        weeklies = extract_expiries(
+            exp_list, count=week_count, predicate=_is_weekly
+        )
 
         self.monthlies = monthlies
         self.weeklies = weeklies


### PR DESCRIPTION
## Summary
- Use `parse_date` in `filter_future_expiries`
- Consolidate expiry extraction with generic `extract_expiries`
- Update market client and tests for new API

## Testing
- `pytest` *(fails: 25 errors during collection)*
- `pytest tests/helpers/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_b_68bbc3d5a748832ea8a78cfc6e124c1d