### PR TITLE
refactor: centralize ratio-like strategies

### DIFF
--- a/tests/strategies/test_ratio_like.py
+++ b/tests/strategies/test_ratio_like.py
@@ -1,0 +1,73 @@
+from copy import deepcopy
+
+from tomic.strategies import StrategyName
+
+BASE_CHAIN = [
+    {"expiry": "20250101", "strike": 100, "type": "call", "bid": 2.0, "ask": 2.2, "delta": 0.4, "edge": 0.5, "model": 0.0, "iv": 0.2},
+    {"expiry": "20250101", "strike": 110, "type": "call", "bid": 0.5, "ask": 0.6, "delta": 0.2, "edge": 0.5, "model": 0.0, "iv": 0.2},
+    {"expiry": "20250101", "strike": 90, "type": "put", "bid": 5.0, "ask": 5.2, "delta": -0.25, "edge": 5.0, "model": 0.0, "iv": 0.2},
+    {"expiry": "20250301", "strike": 80, "type": "put", "bid": 1.0, "ask": 1.1, "delta": -0.15, "edge": 0.5, "model": 0.0, "iv": 0.2},
+    {"expiry": "20250301", "strike": 90, "type": "put", "bid": 1.0, "ask": 1.1, "delta": -0.2, "edge": 0.5, "model": 0.0, "iv": 0.2},
+]
+
+RATIO_CFG = {
+    "min_risk_reward": 0.1,
+    "strike_to_strategy_config": {
+        "short_leg_delta_range": [0.3, 0.45],
+        "long_leg_atr_multiple": 10,
+        "use_ATR": False,
+    },
+}
+
+BACKSPREAD_CFG = {
+    "min_risk_reward": 0.1,
+    "strike_to_strategy_config": {
+        "short_put_delta_range": [-0.3, -0.15],
+        "long_leg_distance_points": 10,
+        "expiry_gap_min_days": 0,
+        "use_ATR": False,
+    },
+}
+
+
+def test_ratio_spread_via_shared_generator(monkeypatch):
+    monkeypatch.setenv("TOMIC_TODAY", "2024-06-01")
+    chain = deepcopy(BASE_CHAIN)
+    import tomic.utils  # ensure utils imported before strategies.utils
+    from tomic.strategies.utils import generate_ratio_like
+    props, reasons = generate_ratio_like(
+        "AAA",
+        chain,
+        RATIO_CFG,
+        100.0,
+        1.0,
+        strategy_name=StrategyName.RATIO_SPREAD,
+        option_type="C",
+        delta_range_key="short_leg_delta_range",
+        use_expiry_pairs=False,
+    )
+    assert props, reasons
+    assert props[0].legs[0]["expiry"] == "20250101"
+    assert props[0].legs[1]["expiry"] == "20250101"
+
+
+def test_backspread_put_via_shared_generator(monkeypatch):
+    monkeypatch.setenv("TOMIC_TODAY", "2024-06-01")
+    chain = deepcopy(BASE_CHAIN)
+    import tomic.utils  # ensure utils imported before strategies.utils
+    from tomic.strategies.utils import generate_ratio_like
+    props, reasons = generate_ratio_like(
+        "AAA",
+        chain,
+        BACKSPREAD_CFG,
+        100.0,
+        1.0,
+        strategy_name=StrategyName.BACKSPREAD_PUT,
+        option_type="P",
+        delta_range_key="short_put_delta_range",
+        use_expiry_pairs=True,
+        max_pairs=3,
+    )
+    assert props, reasons
+    assert props[0].legs[0]["expiry"] == "20250101"
+    assert props[0].legs[1]["expiry"] == "20250301"

--- a/tomic/strategies/backspread_put.py
+++ b/tomic/strategies/backspread_put.py
@@ -1,24 +1,11 @@
 from __future__ import annotations
+
 from typing import Any, Dict, List
+
 from . import StrategyName
-from .utils import (
-    compute_dynamic_width,
-    prepare_option_chain,
-    filter_expiries_by_dte,
-    MAX_PROPOSALS,
-)
-from ..helpers.analysis.scoring import build_leg
-from ..analysis.scoring import calculate_score, passes_risk
-from ..logutils import log_combo_evaluation
-from ..utils import get_leg_right
-from ..strategy_candidates import (
-    StrategyProposal,
-    _build_strike_map,
-    _nearest_strike,
-    _find_option,
-    _validate_ratio,
-    select_expiry_pairs,
-)
+from ..strategy_candidates import StrategyProposal
+from .utils import generate_ratio_like
+
 
 
 def generate(
@@ -28,168 +15,20 @@ def generate(
     spot: float,
     atr: float,
 ) -> tuple[List[StrategyProposal], list[str]]:
-    rules = config.get("strike_to_strategy_config", {})
-    use_atr = bool(rules.get("use_ATR"))
-    if spot is None:
-        raise ValueError("spot price is required")
-    expiries = sorted({str(o.get("expiry")) for o in option_chain})
-    if not expiries:
-        return [], ["geen expiraties beschikbaar"]
-    option_chain = prepare_option_chain(option_chain, spot)
-    strike_map = _build_strike_map(option_chain)
-    proposals: List[StrategyProposal] = []
-    rejected_reasons: list[str] = []
-    min_rr = float(config.get("min_risk_reward", 0.0))
+    """Generate backspread put proposals using shared ratio logic."""
 
-    delta_range = rules.get("short_put_delta_range") or []
-    target_delta = rules.get("long_leg_distance_points")
-    atr_mult = rules.get("long_leg_atr_multiple")
-    min_gap = int(rules.get("expiry_gap_min_days", 0))
-    dte_range = rules.get("dte_range")
-    filtered_expiries = filter_expiries_by_dte(expiries, dte_range)
-    pairs = select_expiry_pairs(filtered_expiries, min_gap)
-    if len(delta_range) == 2 and (target_delta is not None or atr_mult is not None):
-        for near, far in pairs[:3]:
-            short_opt = None
-            for opt in option_chain:
-                if (
-                    str(opt.get("expiry")) == near
-                    and get_leg_right(opt) == "put"
-                    and opt.get("delta") is not None
-                    and delta_range[0] <= float(opt.get("delta")) <= delta_range[1]
-                ):
-                    short_opt = opt
-                    break
-            if not short_opt:
-                reason = "short optie ontbreekt"
-                desc = (
-                    f"near {near} far {far} target_delta {target_delta}"
-                    if target_delta is not None
-                    else f"near {near} far {far} atr_mult {atr_mult}"
-                )
-                log_combo_evaluation(
-                    StrategyName.BACKSPREAD_PUT,
-                    desc,
-                    None,
-                    "reject",
-                    reason,
-                    legs=[{"expiry": near}],
-                )
-                rejected_reasons.append(reason)
-                continue
-            width = compute_dynamic_width(
-                short_opt,
-                target_delta=target_delta,
-                atr_multiple=atr_mult,
-                atr=atr,
-                use_atr=use_atr,
-                option_chain=option_chain,
-                expiry=far,
-                option_type="P",
-            )
-            if width is None:
-                reason = "breedte niet berekend"
-                desc = (
-                    f"near {near} far {far} target_delta {target_delta}"
-                    if target_delta is not None
-                    else f"near {near} far {far} atr_mult {atr_mult}"
-                )
-                log_combo_evaluation(
-                    StrategyName.BACKSPREAD_PUT,
-                    desc,
-                    None,
-                    "reject",
-                    reason,
-                    legs=[
-                        {"expiry": near, "strike": short_opt.get("strike"), "type": "P", "position": -1}
-                    ],
-                )
-                rejected_reasons.append(reason)
-                continue
-            long_strike_target = float(short_opt.get("strike")) - width
-            long_strike = _nearest_strike(strike_map, far, "P", long_strike_target)
-            desc = (
-                f"near {near} far {far} short {short_opt.get('strike')} long {long_strike.matched}"
-            )
-            legs_info = [
-                {"expiry": near, "strike": short_opt.get("strike"), "type": "P", "position": -1},
-                {"expiry": far, "strike": long_strike.matched, "type": "P", "position": 2},
-            ]
-            if not long_strike.matched:
-                reason = "long strike niet gevonden"
-                log_combo_evaluation(
-                    StrategyName.BACKSPREAD_PUT,
-                    desc,
-                    None,
-                    "reject",
-                    reason,
-                    legs=legs_info,
-                )
-                rejected_reasons.append(reason)
-                continue
-            long_opt = _find_option(option_chain, far, long_strike.matched, "P")
-            if not long_opt:
-                reason = "long optie ontbreekt"
-                log_combo_evaluation(
-                    StrategyName.BACKSPREAD_PUT,
-                    desc,
-                    None,
-                    "reject",
-                    reason,
-                    legs=legs_info,
-                )
-                rejected_reasons.append(reason)
-                continue
-            legs = [
-                build_leg({**short_opt, "spot": spot}, "short"),
-                build_leg({**long_opt, "spot": spot}, "long"),
-            ]
-            legs[1]["position"] = 2
-            proposal = StrategyProposal(legs=legs)
-            score, reasons = calculate_score(
-                StrategyName.BACKSPREAD_PUT, proposal, spot
-            )
-            if score is not None and passes_risk(proposal, min_rr):
-                if _validate_ratio(
-                    "backspread_put", legs, proposal.credit or 0.0
-                ):
-                    proposals.append(proposal)
-                    log_combo_evaluation(
-                        StrategyName.BACKSPREAD_PUT,
-                        desc,
-                        proposal.__dict__,
-                        "pass",
-                        "criteria",
-                        legs=legs,
-                    )
-                else:
-                    reason = "verkeerde ratio"
-                    log_combo_evaluation(
-                        StrategyName.BACKSPREAD_PUT,
-                        desc,
-                        proposal.__dict__,
-                        "reject",
-                        reason,
-                        legs=legs,
-                    )
-                    rejected_reasons.append(reason)
-            else:
-                reason = "; ".join(reasons) if reasons else "risk/reward onvoldoende"
-                log_combo_evaluation(
-                    StrategyName.BACKSPREAD_PUT,
-                    desc,
-                    proposal.__dict__,
-                    "reject",
-                    reason,
-                    legs=legs,
-                )
-                if reasons:
-                    rejected_reasons.extend(reasons)
-                else:
-                    rejected_reasons.append("risk/reward onvoldoende")
-    else:
-        rejected_reasons.append("ongeldige delta range")
-    proposals.sort(key=lambda p: p.score or 0, reverse=True)
-    if not proposals:
-        return [], sorted(set(rejected_reasons))
-    return proposals[:MAX_PROPOSALS], sorted(set(rejected_reasons))
+    return generate_ratio_like(
+        symbol,
+        option_chain,
+        config,
+        spot,
+        atr,
+        strategy_name=StrategyName.BACKSPREAD_PUT,
+        option_type="P",
+        delta_range_key="short_put_delta_range",
+        use_expiry_pairs=True,
+        max_pairs=3,
+    )
+
+
+__all__ = ["generate"]

--- a/tomic/strategies/ratio_spread.py
+++ b/tomic/strategies/ratio_spread.py
@@ -1,25 +1,11 @@
 from __future__ import annotations
+
 from typing import Any, Dict, List
-import math
+
 from . import StrategyName
-from .utils import (
-    compute_dynamic_width,
-    prepare_option_chain,
-    filter_expiries_by_dte,
-    MAX_PROPOSALS,
-    reached_limit,
-)
-from ..helpers.analysis.scoring import build_leg
-from ..analysis.scoring import calculate_score, passes_risk
-from ..utils import get_option_mid_price, get_leg_right
-from ..logutils import log_combo_evaluation
-from ..strategy_candidates import (
-    StrategyProposal,
-    _build_strike_map,
-    _nearest_strike,
-    _find_option,
-    _validate_ratio,
-)
+from ..strategy_candidates import StrategyProposal
+from .utils import generate_ratio_like
+
 
 
 def generate(
@@ -29,182 +15,19 @@ def generate(
     spot: float,
     atr: float,
 ) -> tuple[List[StrategyProposal], list[str]]:
-    rules = config.get("strike_to_strategy_config", {})
-    use_atr = bool(rules.get("use_ATR"))
-    if spot is None:
-        raise ValueError("spot price is required")
-    option_chain = prepare_option_chain(option_chain, spot)
-    expiries = sorted({str(o.get("expiry")) for o in option_chain})
-    if not expiries:
-        return [], ["geen expiraties beschikbaar"]
-    strike_map = _build_strike_map(option_chain)
-    proposals: List[StrategyProposal] = []
-    rejected_reasons: list[str] = []
-    min_rr = float(config.get("min_risk_reward", 0.0))
+    """Generate ratio spread proposals using shared ratio logic."""
 
-    delta_range = rules.get("short_leg_delta_range") or []
-    target_delta = rules.get("long_leg_distance_points")
-    atr_mult = rules.get("long_leg_atr_multiple")
-    dte_range = rules.get("dte_range")
-    expiries = filter_expiries_by_dte(expiries, dte_range)
-    if len(delta_range) == 2 and (target_delta is not None or atr_mult is not None):
-        for expiry in expiries:
-            calls_pre = []
-            for opt in option_chain:
-                if str(opt.get("expiry")) != expiry:
-                    rejected_reasons.append("verkeerde expiratie")
-                    continue
-                if get_leg_right(opt) != "call":
-                    rejected_reasons.append("geen call optie")
-                    continue
-                delta = opt.get("delta")
-                mid, _ = get_option_mid_price(opt)
-                if delta is None or not (delta_range[0] <= float(delta) <= delta_range[1]):
-                    rejected_reasons.append("delta buiten range")
-                    continue
-                try:
-                    mid_val = float(mid) if mid is not None else math.nan
-                except Exception:
-                    mid_val = math.nan
-                if math.isnan(mid_val):
-                    rejected_reasons.append("mid ontbreekt")
-                    continue
-                calls_pre.append(opt)
-            call_strikes = {float(o.get("strike")) for o in calls_pre}
-            short_opt = None
-            for opt in option_chain:
-                if (
-                    str(opt.get("expiry")) == expiry
-                    and get_leg_right(opt) == "call"
-                    and opt.get("delta") is not None
-                    and delta_range[0] <= float(opt.get("delta")) <= delta_range[1]
-                ):
-                    short_opt = opt
-                    break
-            if not short_opt:
-                reason = "short optie ontbreekt"
-                desc = (
-                    f"target_delta {target_delta}" if target_delta is not None else f"atr_mult {atr_mult}"
-                )
-                log_combo_evaluation(
-                    StrategyName.RATIO_SPREAD,
-                    desc,
-                    None,
-                    "reject",
-                    reason,
-                    legs=[{"expiry": expiry}],
-                )
-                rejected_reasons.append(reason)
-                continue
-            width = compute_dynamic_width(
-                short_opt,
-                target_delta=target_delta,
-                atr_multiple=atr_mult,
-                atr=atr,
-                use_atr=use_atr,
-                option_chain=option_chain,
-                expiry=expiry,
-                option_type="C",
-            )
-            if width is None:
-                reason = "breedte niet berekend"
-                desc = (
-                    f"target_delta {target_delta}" if target_delta is not None else f"atr_mult {atr_mult}"
-                )
-                log_combo_evaluation(
-                    StrategyName.RATIO_SPREAD,
-                    desc,
-                    None,
-                    "reject",
-                    reason,
-                    legs=[
-                        {"expiry": expiry, "strike": short_opt.get("strike"), "type": "C", "position": -1}
-                    ],
-                )
-                rejected_reasons.append(reason)
-                continue
-            long_strike_target = float(short_opt.get("strike")) + width
-            long_strike = _nearest_strike(strike_map, expiry, "C", long_strike_target)
-            desc = f"short {short_opt.get('strike')} long {long_strike.matched}"
-            legs_info = [
-                {"expiry": expiry, "strike": short_opt.get("strike"), "type": "C", "position": -1},
-                {"expiry": expiry, "strike": long_strike.matched, "type": "C", "position": 2},
-            ]
-            if not long_strike.matched:
-                reason = "long strike niet gevonden"
-                log_combo_evaluation(
-                    StrategyName.RATIO_SPREAD,
-                    desc,
-                    None,
-                    "reject",
-                    reason,
-                    legs=legs_info,
-                )
-                rejected_reasons.append(reason)
-                continue
-            long_opt = _find_option(option_chain, expiry, long_strike.matched, "C")
-            if not long_opt:
-                reason = "long optie ontbreekt"
-                log_combo_evaluation(
-                    StrategyName.RATIO_SPREAD,
-                    desc,
-                    None,
-                    "reject",
-                    reason,
-                    legs=legs_info,
-                )
-                rejected_reasons.append(reason)
-                continue
-            legs = [
-                build_leg({**short_opt, "spot": spot}, "short"),
-                build_leg({**long_opt, "spot": spot}, "long"),
-            ]
-            legs[1]["position"] = 2
-            proposal = StrategyProposal(legs=legs)
-            score, reasons = calculate_score(
-                StrategyName.RATIO_SPREAD, proposal, spot
-            )
-            if score is not None and passes_risk(proposal, min_rr):
-                if _validate_ratio("ratio_spread", legs, proposal.credit or 0.0):
-                    proposals.append(proposal)
-                    log_combo_evaluation(
-                        StrategyName.RATIO_SPREAD,
-                        desc,
-                        proposal.__dict__,
-                        "pass",
-                        "criteria",
-                        legs=legs,
-                    )
-                else:
-                    reason = "verkeerde ratio"
-                    log_combo_evaluation(
-                        StrategyName.RATIO_SPREAD,
-                        desc,
-                        proposal.__dict__,
-                        "reject",
-                        reason,
-                        legs=legs,
-                    )
-                    rejected_reasons.append(reason)
-            else:
-                reason = "; ".join(reasons) if reasons else "risk/reward onvoldoende"
-                log_combo_evaluation(
-                    StrategyName.RATIO_SPREAD,
-                    desc,
-                    proposal.__dict__,
-                    "reject",
-                    reason,
-                    legs=legs,
-                )
-                if reasons:
-                    rejected_reasons.extend(reasons)
-                else:
-                    rejected_reasons.append("risk/reward onvoldoende")
-            if reached_limit(proposals):
-                break
-    else:
-        rejected_reasons.append("ongeldige delta range")
-    proposals.sort(key=lambda p: p.score or 0, reverse=True)
-    if not proposals:
-        return [], sorted(set(rejected_reasons))
-    return proposals[:MAX_PROPOSALS], sorted(set(rejected_reasons))
+    return generate_ratio_like(
+        symbol,
+        option_chain,
+        config,
+        spot,
+        atr,
+        strategy_name=StrategyName.RATIO_SPREAD,
+        option_type="C",
+        delta_range_key="short_leg_delta_range",
+        use_expiry_pairs=False,
+    )
+
+
+__all__ = ["generate"]

--- a/tomic/utils.py
+++ b/tomic/utils.py
@@ -20,11 +20,12 @@ def today() -> date:
     return date.today()
 
 
-from tomic.helpers.dateutils import parse_date
 
 
 def filter_future_expiries(expirations: list[str]) -> list[str]:
     """Return expiries after :func:`today` sorted chronologically."""
+
+    from tomic.helpers.dateutils import parse_date
 
     future_dates: list[date] = []
     today_date = today()
@@ -51,6 +52,8 @@ def extract_expiries(
     predicate: Callable[[date], bool],
 ) -> list[str]:
     """Return the next ``count`` expiries matching ``predicate``."""
+
+    from tomic.helpers.dateutils import parse_date
 
     selected: list[str] = []
     for exp in filter_future_expiries(expirations):


### PR DESCRIPTION
## Summary
- extract shared `generate_ratio_like` helper for ratio-style strategies
- slim down `backspread_put` and `ratio_spread` to wrappers
- cover new helper with dedicated tests

## Testing
- `pytest tests/strategies/test_ratio_like.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bbc7ca7224832ebe32da69f64276c9