### PR TITLE
Use explicit None checks in leg metrics validation

### DIFF
--- a/tomic/analysis/scoring.py
+++ b/tomic/analysis/scoring.py
@@ -73,25 +73,26 @@ def calculate_breakevens(
 
 def validate_leg_metrics(strategy_name: str, legs: List[Dict[str, Any]]) -> Tuple[bool, List[str]]:
     """Ensure required leg metrics are present."""
-    missing_fields = False
+    missing_fields: set[str] = set()
     for leg in legs:
         missing: List[str] = []
-        if not leg.get("mid"):
+        if leg.get("mid") is None:
             missing.append("mid")
-        if not leg.get("model"):
+        if leg.get("model") is None:
             missing.append("model")
-        if not leg.get("delta"):
+        if leg.get("delta") is None:
             missing.append("delta")
         if missing:
             logger.info(
                 f"[leg-missing] {leg['type']} {leg['strike']} {leg['expiry']}: {', '.join(missing)}"
             )
-            missing_fields = True
+            missing_fields.update(missing)
     if missing_fields:
         logger.info(
             f"[❌ voorstel afgewezen] {strategy_name} — reason: ontbrekende metrics (details in debug)"
         )
-        return False, ["Edge, model of delta ontbreekt — metrics kunnen niet worden berekend"]
+        missing_str = ", ".join(sorted(missing_fields))
+        return False, [f"{missing_str} ontbreken — metrics kunnen niet worden berekend"]
     return True, []
 
 


### PR DESCRIPTION
## Summary
- use explicit `is None` checks for leg metrics
- include specific missing metrics in error messages

## Testing
- `pytest tests/analysis/test_scoring_helpers.py::test_validate_leg_metrics_missing -q`
- `pytest` *(fails: TypeError: object() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_b_68bd2e1d1190832eabc0ca60fc65a244